### PR TITLE
Feat: JBERC20 create2

### DIFF
--- a/src/JBController.sol
+++ b/src/JBController.sol
@@ -629,7 +629,8 @@ contract JBController is JBPermissioned, ERC2771Context, ERC165, IJBController, 
     function deployERC20For(
         uint256 projectId,
         string calldata name,
-        string calldata symbol
+        string calldata symbol,
+        bytes32 salt
     )
         external
         virtual
@@ -643,7 +644,9 @@ contract JBController is JBPermissioned, ERC2771Context, ERC165, IJBController, 
             permissionId: JBPermissionIds.ISSUE_TOKEN
         });
 
-        return TOKENS.deployERC20For(projectId, name, symbol);
+        bytes32 _salt = salt == bytes32(0) ? salt : keccak256(abi.encodePacked(_msgSender(), salt));
+
+        return TOKENS.deployERC20For(projectId, name, symbol, _salt);
     }
 
     /// @notice Set a project's token if not already set.

--- a/src/JBController.sol
+++ b/src/JBController.sol
@@ -644,9 +644,9 @@ contract JBController is JBPermissioned, ERC2771Context, ERC165, IJBController, 
             permissionId: JBPermissionIds.ISSUE_TOKEN
         });
 
-        bytes32 _salt = salt == bytes32(0) ? salt : keccak256(abi.encodePacked(_msgSender(), salt));
+        salt = salt == bytes32(0) ? salt : keccak256(abi.encodePacked(_msgSender(), salt));
 
-        return TOKENS.deployERC20For(projectId, name, symbol, _salt);
+        return TOKENS.deployERC20For(projectId, name, symbol, salt);
     }
 
     /// @notice Set a project's token if not already set.

--- a/src/JBController.sol
+++ b/src/JBController.sol
@@ -644,7 +644,7 @@ contract JBController is JBPermissioned, ERC2771Context, ERC165, IJBController, 
             permissionId: JBPermissionIds.ISSUE_TOKEN
         });
 
-        salt = salt == bytes32(0) ? salt : keccak256(abi.encodePacked(_msgSender(), salt));
+        if (salt != bytes32(0)) salt = keccak256(abi.encodePacked(_msgSender(), salt));
 
         return TOKENS.deployERC20For(projectId, name, symbol, salt);
     }

--- a/src/JBTokens.sol
+++ b/src/JBTokens.sol
@@ -113,7 +113,8 @@ contract JBTokens is JBControlled, IJBTokens {
     function deployERC20For(
         uint256 projectId,
         string calldata name,
-        string calldata symbol
+        string calldata symbol,
+        bytes32 salt
     )
         external
         override
@@ -129,8 +130,9 @@ contract JBTokens is JBControlled, IJBTokens {
         // The project shouldn't already have a token.
         if (tokenOf[projectId] != IJBToken(address(0))) revert PROJECT_ALREADY_HAS_TOKEN();
 
-        // Deploy the token contract.
-        token = new JBERC20(name, symbol, address(this));
+        token = salt == bytes32(0)
+            ? new JBERC20(name, symbol, address(this))
+            : new JBERC20{salt: salt}(name, symbol, address(this));
 
         // Store the token contract.
         tokenOf[projectId] = token;

--- a/src/JBTokens.sol
+++ b/src/JBTokens.sol
@@ -140,7 +140,7 @@ contract JBTokens is JBControlled, IJBTokens {
         // Store the project for the token.
         projectIdOf[token] = projectId;
 
-        emit DeployERC20(projectId, token, name, symbol, msg.sender);
+        emit DeployERC20(projectId, token, name, symbol, salt, msg.sender);
     }
 
     /// @notice Set a project's token if not already set.

--- a/src/interfaces/IJBController.sol
+++ b/src/interfaces/IJBController.sol
@@ -168,7 +168,8 @@ interface IJBController is IERC165, IJBProjectUriRegistry, IJBDirectoryAccessCon
     function deployERC20For(
         uint256 projectId,
         string calldata name,
-        string calldata symbol
+        string calldata symbol,
+        bytes32 salt
     )
         external
         returns (IJBToken token);

--- a/src/interfaces/IJBTokens.sol
+++ b/src/interfaces/IJBTokens.sol
@@ -5,7 +5,7 @@ import {IJBToken} from "./IJBToken.sol";
 import {IJBControlled} from "./IJBControlled.sol";
 
 interface IJBTokens is IJBControlled {
-    event DeployERC20(uint256 indexed projectId, IJBToken indexed token, string name, string symbol, address caller);
+    event DeployERC20(uint256 indexed projectId, IJBToken indexed token, string name, string symbol, bytes32 salt, address caller);
 
     event Mint(
         address indexed holder, uint256 indexed projectId, uint256 amount, bool tokensWereClaimed, address caller

--- a/src/interfaces/IJBTokens.sol
+++ b/src/interfaces/IJBTokens.sol
@@ -5,7 +5,9 @@ import {IJBToken} from "./IJBToken.sol";
 import {IJBControlled} from "./IJBControlled.sol";
 
 interface IJBTokens is IJBControlled {
-    event DeployERC20(uint256 indexed projectId, IJBToken indexed token, string name, string symbol, bytes32 salt, address caller);
+    event DeployERC20(
+        uint256 indexed projectId, IJBToken indexed token, string name, string symbol, bytes32 salt, address caller
+    );
 
     event Mint(
         address indexed holder, uint256 indexed projectId, uint256 amount, bool tokensWereClaimed, address caller

--- a/src/interfaces/IJBTokens.sol
+++ b/src/interfaces/IJBTokens.sol
@@ -50,7 +50,8 @@ interface IJBTokens is IJBControlled {
     function deployERC20For(
         uint256 projectId,
         string calldata name,
-        string calldata symbol
+        string calldata symbol,
+        bytes32 salt
     )
         external
         returns (IJBToken token);

--- a/test/TestPayBurnRedeemFlow.sol
+++ b/test/TestPayBurnRedeemFlow.sol
@@ -90,7 +90,7 @@ contract TestPayBurnRedeemFlow_Local is TestBaseWorkflow {
     {
         // Issue an ERC-20 token for project.
         vm.prank(_projectOwner);
-        _controller.deployERC20For(_projectId, "TestName", "TestSymbol");
+        _controller.deployERC20For(_projectId, "TestName", "TestSymbol", bytes32(0));
 
         // Make a payment.
         _terminal.pay{value: _nativePayAmount}({

--- a/test/TestRedeem.sol
+++ b/test/TestRedeem.sol
@@ -82,7 +82,7 @@ contract TestRedeem_Local is TestBaseWorkflow {
 
         // Issue the project's tokens.
         vm.prank(_projectOwner);
-        _controller.deployERC20For(_projectId, "TestName", "TestSymbol");
+        _controller.deployERC20For(_projectId, "TestName", "TestSymbol", bytes32(0));
 
         // Pay the project.
         _terminal.pay{value: _nativePayAmount}({

--- a/test/TestRedeemHooks.sol
+++ b/test/TestRedeemHooks.sol
@@ -80,7 +80,7 @@ contract TestRedeemHooks_Local is TestBaseWorkflow {
 
         // Issue the project's tokens.
         vm.prank(_projectOwner);
-        IJBToken _token = _controller.deployERC20For(_projectId, "TestName", "TestSymbol");
+        IJBToken _token = _controller.deployERC20For(_projectId, "TestName", "TestSymbol", bytes32(0));
 
         // Make sure the project's new project token is set.
         assertEq(address(_tokens.tokenOf(_projectId)), address(_token));

--- a/test/TestTokenFlow.sol
+++ b/test/TestTokenFlow.sol
@@ -71,7 +71,7 @@ contract TestTokenFlow_Local is TestBaseWorkflow {
 
         if (_issueToken) {
             // Issue an ERC-20 token for project.
-            _controller.deployERC20For({projectId: _projectId, name: "TestName", symbol: "TestSymbol"});
+            _controller.deployERC20For({projectId: _projectId, name: "TestName", symbol: "TestSymbol", salt: bytes32(0)});
         } else {
             // Create a new `IJBToken` and change it's owner to the `JBTokens` contract.
             IJBToken _newToken = new JBERC20({name: "NewTestName", symbol: "NewTestSymbol", owner: _projectOwner});
@@ -141,7 +141,7 @@ contract TestTokenFlow_Local is TestBaseWorkflow {
         vm.startPrank(_projectOwner);
 
         // Issue an ERC-20 token for project.
-        _controller.deployERC20For({projectId: _projectId, name: "TestName", symbol: "TestSymbol"});
+        _controller.deployERC20For({projectId: _projectId, name: "TestName", symbol: "TestSymbol", salt: bytes32(0)});
 
         // Mint claimed tokens to beneficiary: since this is 1,000 over `uint(208)` it will revert.
         vm.expectRevert(abi.encodeWithSignature("OVERFLOW_ALERT()"));


### PR DESCRIPTION
# Description

Adds to JBC and JBTokens the ability for deterministic deploys. If the provided salt == bytes32(0) we deploy without create2. Relies on this deterministic deployer (defined in solidity spec): 

https://docs.soliditylang.org/en/latest/control-structures.html#salted-contract-creations-create2

## Limitations & risks

Reliance on the deterministic deployer contract, but we can deploy it to any chain easily.
https://github.com/Arachnid/deterministic-deployment-proxy

# Check-list
- [x] Tests are covering the new feature
- [x] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [x] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [x] I have run the test locally (and they pass)
- [x] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly: JBController / JBTokens

- Indirectly: