### PR TITLE
Feature/redeem hook returns rate

### DIFF
--- a/src/JBMultiTerminal.sol
+++ b/src/JBMultiTerminal.sol
@@ -1029,7 +1029,7 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
 
         // Scoped section prevents stack too deep.
         {
-            JBAccountingContext[] memory balanceAccountingContexts = ;
+            JBAccountingContext[] memory balanceAccountingContexts = _accountingContextsOf[projectId];
 
             // Record the redemption.
             (ruleset, reclaimAmount, redemptionRate, hookSpecifications) = STORE.recordRedemptionFor({

--- a/src/JBMultiTerminal.sol
+++ b/src/JBMultiTerminal.sol
@@ -1099,6 +1099,7 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
             holder,
             beneficiary,
             redeemCount,
+            ruleset.redemptionRate(),
             reclaimAmount,
             metadata,
             _msgSender()

--- a/src/JBMultiTerminal.sol
+++ b/src/JBMultiTerminal.sol
@@ -1003,6 +1003,7 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
     /// applicable.
     /// @return reclaimAmount The number of terminal tokens reclaimed for the `beneficiary`, as a fixed point number
     /// with 18 decimals.
+
     function _redeemTokensOf(
         address holder,
         uint256 projectId,
@@ -1047,10 +1048,9 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
         if (reclaimAmount != 0) {
             // Determine if a fee should be taken. Fees are not exercised if the redemption rate is at its max (100%),
             // if the beneficiary is feeless, or if the fee beneficiary doesn't accept the given token.
-            bool takesFee =
-                !FEELESS_ADDRESSES.isFeeless(beneficiary) && ruleset.redemptionRate() != JBConstants.MAX_REDEMPTION_RATE;
-
-            if (takesFee) {
+            if (
+                !FEELESS_ADDRESSES.isFeeless(beneficiary) && ruleset.redemptionRate() != JBConstants.MAX_REDEMPTION_RATE
+            ) {
                 amountEligibleForFees += reclaimAmount;
                 // Subtract the fee for the reclaimed amount.
                 reclaimAmount -= JBFees.feeAmountIn(reclaimAmount, FEE);

--- a/src/JBRulesets.sol
+++ b/src/JBRulesets.sol
@@ -393,8 +393,8 @@ contract JBRulesets is JBControlled, IJBRulesets {
         // Weight must fit into a uint88.
         if (weight > type(uint88).max) revert INVALID_WEIGHT();
 
-        // If the start date is in the past, set it to be the current timestamp.
-        if (mustStartAtOrAfter < block.timestamp) {
+        // If the start date is not set, set it to be the current timestamp.
+        if (mustStartAtOrAfter == 0) {
             mustStartAtOrAfter = block.timestamp;
         }
 

--- a/src/JBTerminalStore.sol
+++ b/src/JBTerminalStore.sol
@@ -415,7 +415,7 @@ contract JBTerminalStore is ReentrancyGuard, IJBTerminalStore {
     /// have a redemption rate provided by the redemption hook if applicable.
     /// @return reclaimAmount The amount of tokens reclaimed from the terminal, as a fixed point number with 18
     /// decimals.
-    /// @param redemptionRate The redemption rate influencing the reclaim amount.
+    /// @return redemptionRate The redemption rate influencing the reclaim amount.
     /// @return hookSpecifications A list of redeem hooks, including data and amounts to send to them. The terminal
     /// should fulfill these specifications.
 

--- a/src/JBTerminalStore.sol
+++ b/src/JBTerminalStore.sol
@@ -417,6 +417,7 @@ contract JBTerminalStore is ReentrancyGuard, IJBTerminalStore {
     /// decimals.
     /// @return hookSpecifications A list of redeem hooks, including data and amounts to send to them. The terminal
     /// should fulfill these specifications.
+
     function recordRedemptionFor(
         address holder,
         uint256 projectId,

--- a/src/interfaces/IJBRulesetDataHook.sol
+++ b/src/interfaces/IJBRulesetDataHook.sol
@@ -34,10 +34,11 @@ interface IJBRulesetDataHook is IERC165 {
     /// terminal's `redeemTokensOf(...)` transaction.
     /// @param context The context passed to this data hook by the `redeemTokensOf(...)` function as a
     /// `JBBeforeRedeemRecordedContext` struct.
-    /// @return reclaimAmount The amount to claim, overriding the terminal logic.
+    /// @return redemptionRate The rate determining the amount that should be reclaimable for a given surplus and token
+    /// supply.
     /// @return hookSpecifications The amount and data to send to redeem hooks instead of returning to the beneficiary.
     function beforeRedeemRecordedWith(JBBeforeRedeemRecordedContext calldata context)
         external
         view
-        returns (uint256 reclaimAmount, JBRedeemHookSpecification[] memory hookSpecifications);
+        returns (uint256 redemptionRate, JBRedeemHookSpecification[] memory hookSpecifications);
 }

--- a/src/interfaces/IJBTerminalStore.sol
+++ b/src/interfaces/IJBTerminalStore.sol
@@ -103,7 +103,12 @@ interface IJBTerminalStore {
         bytes calldata metadata
     )
         external
-        returns (JBRuleset memory ruleset, uint256 reclaimAmount, JBRedeemHookSpecification[] memory hookSpecifications);
+        returns (
+            JBRuleset memory ruleset,
+            uint256 reclaimAmount,
+            uint256 redemptionRate,
+            JBRedeemHookSpecification[] memory hookSpecifications
+        );
 
     function recordPayoutFor(
         uint256 projectId,

--- a/src/interfaces/terminal/IJBRedeemTerminal.sol
+++ b/src/interfaces/terminal/IJBRedeemTerminal.sol
@@ -14,6 +14,7 @@ interface IJBRedeemTerminal is IJBTerminal {
         address holder,
         address beneficiary,
         uint256 tokenCount,
+        uint256 redemptionRate,
         uint256 reclaimedAmount,
         bytes metadata,
         address caller

--- a/src/libraries/JBRulesetMetadataResolver.sol
+++ b/src/libraries/JBRulesetMetadataResolver.sol
@@ -17,7 +17,9 @@ library JBRulesetMetadataResolver {
     function setRedemptionRateTo(JBRuleset memory ruleset, uint256 value) internal pure returns (JBRuleset memory) {
         // redemption rate in bits 20-35 (16 bits).
         // redemption rate is a number 0-10000.
-        ruleset.metadata |= value << 20;
+        JBRulesetMetadata memory adjustedMetadata = expandMetadata(ruleset);
+        adjustedMetadata.redemptionRate = value;
+        ruleset.metadata = packRulesetMetadata(adjustedMetadata);
         return ruleset;
     }
 

--- a/src/libraries/JBRulesetMetadataResolver.sol
+++ b/src/libraries/JBRulesetMetadataResolver.sol
@@ -14,6 +14,13 @@ library JBRulesetMetadataResolver {
         return uint256(uint16(ruleset.metadata >> 20));
     }
 
+    function setRedemptionRateTo(JBRuleset memory ruleset, uint256 value) internal pure returns (JBRuleset memory) {
+        // redemption rate in bits 20-35 (16 bits).
+        // redemption rate is a number 0-10000.
+        ruleset.metadata |= value << 20;
+        return ruleset;
+    }
+
     function baseCurrency(JBRuleset memory ruleset) internal pure returns (uint256) {
         // Currency is a number 0-4294967296.
         return uint256(uint32(ruleset.metadata >> 36));

--- a/src/structs/JBBeforeRedeemRecordedContext.sol
+++ b/src/structs/JBBeforeRedeemRecordedContext.sol
@@ -12,9 +12,8 @@ import {JBTokenAmount} from "./JBTokenAmount.sol";
 /// @custom:member totalSupply The total token supply being used for the calculation, as a fixed point number with 18
 /// decimals.
 /// @custom:member surplus The surplus amount used for the calculation, as a fixed point number with 18 decimals.
-/// @custom:member reclaimAmount The token amount that should be reclaimed by the redeemer using the protocol's standard
-/// bonding curve redemption formula. Includes the token being reclaimed, the reclaim value, the number of decimals
-/// included, and the currency of the reclaim amount.
+/// Includes the token of the surplus, the surplus value, the number of decimals
+/// included, and the currency of the surplus.
 /// @custom:member useTotalSurplus If surplus across all of a project's terminals is being used when making redemptions.
 /// @custom:member redemptionRate The redemption rate of the ruleset the redemption is being made during.
 /// @custom:member metadata Extra data provided by the redeemer.
@@ -25,8 +24,7 @@ struct JBBeforeRedeemRecordedContext {
     uint256 rulesetId;
     uint256 redeemCount;
     uint256 totalSupply;
-    uint256 surplus;
-    JBTokenAmount reclaimAmount;
+    JBTokenAmount surplus;
     bool useTotalSurplus;
     uint256 redemptionRate;
     bytes metadata;


### PR DESCRIPTION
# Description

Adjust redemption hook interfaces to:
- allow hook to specify redemption rate _instead of_ reclaimAmount. 
- redemption fee based on redemption rate returned from hook. if MAX, no fee. 

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: