### PR TITLE
fix: order of operations when calling an AfterRedeemRecordedHook

### DIFF
--- a/src/JBMultiTerminal.sol
+++ b/src/JBMultiTerminal.sol
@@ -1469,13 +1469,6 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
             // Set the specification being iterated on.
             specification = specifications[i];
 
-            // Trigger any inherited pre-transfer logic.
-            _beforeTransferTo({
-                to: address(specification.hook),
-                token: beneficiaryReclaimAmount.token,
-                amount: specification.amount
-            });
-
             // Get the fee for the specified amount.
             uint256 specificationAmountFee = takesFee ? JBFees.feeAmountIn(specification.amount, FEE) : 0;
 
@@ -1495,6 +1488,13 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
 
             // Pass the correct metadata from the data hook's specification.
             context.hookMetadata = specification.metadata;
+
+            // Trigger any inherited pre-transfer logic.
+            _beforeTransferTo({
+                to: address(specification.hook),
+                token: beneficiaryReclaimAmount.token,
+                amount: specification.amount
+            });
 
             // Keep a reference to the amount that'll be paid as a `msg.value`.
             uint256 payValue = beneficiaryReclaimAmount.token == JBConstants.NATIVE_TOKEN ? specification.amount : 0;


### PR DESCRIPTION
# Description

*What does this PR: do, how, why?*

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: