### PR TITLE
redeem hook returns token count and total tokens

### DIFF
--- a/src/JBTerminalStore.sol
+++ b/src/JBTerminalStore.sol
@@ -418,7 +418,6 @@ contract JBTerminalStore is ReentrancyGuard, IJBTerminalStore {
     /// @return redemptionRate The redemption rate influencing the reclaim amount.
     /// @return hookSpecifications A list of redeem hooks, including data and amounts to send to them. The terminal
     /// should fulfill these specifications.
-
     function recordRedemptionFor(
         address holder,
         uint256 projectId,
@@ -486,7 +485,7 @@ contract JBTerminalStore is ReentrancyGuard, IJBTerminalStore {
                 metadata: metadata
             });
 
-            (redemptionRate, hookSpecifications) =
+            (redemptionRate, redeemCount, totalSupply, hookSpecifications) =
                 IJBRulesetDataHook(ruleset.dataHook()).beforeRedeemRecordedWith(context);
         } else {
             redemptionRate = ruleset.redemptionRate();

--- a/src/interfaces/IJBRulesetDataHook.sol
+++ b/src/interfaces/IJBRulesetDataHook.sol
@@ -36,9 +36,16 @@ interface IJBRulesetDataHook is IERC165 {
     /// `JBBeforeRedeemRecordedContext` struct.
     /// @return redemptionRate The rate determining the amount that should be reclaimable for a given surplus and token
     /// supply.
+    /// @return redeemCount The amount of tokens that should be considered redeemed.
+    /// @return totalSupply The total amount of tokens that are considered to be existing.
     /// @return hookSpecifications The amount and data to send to redeem hooks instead of returning to the beneficiary.
     function beforeRedeemRecordedWith(JBBeforeRedeemRecordedContext calldata context)
         external
         view
-        returns (uint256 redemptionRate, JBRedeemHookSpecification[] memory hookSpecifications);
+        returns (
+            uint256 redemptionRate,
+            uint256 redeemCount,
+            uint256 totalSupply,
+            JBRedeemHookSpecification[] memory hookSpecifications
+        );
 }

--- a/test/TestRedeemHooks.sol
+++ b/test/TestRedeemHooks.sol
@@ -177,7 +177,9 @@ contract TestRedeemHooks_Local is TestBaseWorkflow {
         vm.mockCall(
             _DATA_HOOK,
             abi.encodeWithSelector(IJBRulesetDataHook.beforeRedeemRecordedWith.selector),
-            abi.encode(_ruleset.redemptionRate(), _specifications)
+            abi.encode(
+                _ruleset.redemptionRate(), _beneficiaryTokenBalance / 2, _beneficiaryTokenBalance, _specifications
+            )
         );
 
         _terminal.redeemTokensOf({
@@ -191,7 +193,7 @@ contract TestRedeemHooks_Local is TestBaseWorkflow {
         });
     }
 
-    function testRedeemHookWithFeesAndCustomRedemptionRate() public {
+    function testRedeemHookWithFeesAndCustomInfo() public {
         // Reference and bound pay amount.
         uint256 _nativePayAmount = 10 ether;
         uint256 _halfPaid = 5 ether;
@@ -235,18 +237,16 @@ contract TestRedeemHooks_Local is TestBaseWorkflow {
             JBRedeemHookSpecification({hook: IJBRedeemHook(_redeemHook), amount: _halfPaid, metadata: ""});
 
         uint256 _customRedemptionRate = JBConstants.MAX_REDEMPTION_RATE / 2;
+        uint256 _customTokenCount = 1 * 10 ** 18;
+        uint256 _customTotalTokens = 5 * 10 ** 18;
 
         uint256 _forwardedAmount =
             _halfPaid - (_halfPaid - mulDiv(_halfPaid, JBConstants.MAX_FEE, _terminal.FEE() + JBConstants.MAX_FEE));
 
         uint256 _beneficiaryAmount = mulDiv(
-            mulDiv(_nativePayAmount, _beneficiaryTokenBalance / 2, _beneficiaryTokenBalance),
+            mulDiv(_nativePayAmount, _customTokenCount, _customTotalTokens),
             _customRedemptionRate
-                + mulDiv(
-                    _beneficiaryTokenBalance / 2,
-                    JBConstants.MAX_REDEMPTION_RATE - _customRedemptionRate,
-                    _beneficiaryTokenBalance
-                ),
+                + mulDiv(_customTokenCount, JBConstants.MAX_REDEMPTION_RATE - _customRedemptionRate, _customTotalTokens),
             JBConstants.MAX_REDEMPTION_RATE
         );
 
@@ -295,7 +295,7 @@ contract TestRedeemHooks_Local is TestBaseWorkflow {
         vm.mockCall(
             _DATA_HOOK,
             abi.encodeWithSelector(IJBRulesetDataHook.beforeRedeemRecordedWith.selector),
-            abi.encode(_customRedemptionRate, _specifications)
+            abi.encode(_customRedemptionRate, _customTokenCount, _customTotalTokens, _specifications)
         );
 
         _terminal.redeemTokensOf({

--- a/test/TestRedeemHooks.sol
+++ b/test/TestRedeemHooks.sol
@@ -237,16 +237,16 @@ contract TestRedeemHooks_Local is TestBaseWorkflow {
             JBRedeemHookSpecification({hook: IJBRedeemHook(_redeemHook), amount: _halfPaid, metadata: ""});
 
         uint256 _customRedemptionRate = JBConstants.MAX_REDEMPTION_RATE / 2;
-        uint256 _customTokenCount = 1 * 10 ** 18;
-        uint256 _customTotalTokens = 5 * 10 ** 18;
+        uint256 _customRedeemCount = 1 * 10 ** 18;
+        uint256 _customTotalSupply = 5 * 10 ** 18;
 
         uint256 _forwardedAmount =
             _halfPaid - (_halfPaid - mulDiv(_halfPaid, JBConstants.MAX_FEE, _terminal.FEE() + JBConstants.MAX_FEE));
 
         uint256 _beneficiaryAmount = mulDiv(
-            mulDiv(_nativePayAmount, _customTokenCount, _customTotalTokens),
+            mulDiv(_nativePayAmount, _customRedeemCount, _customTotalSupply),
             _customRedemptionRate
-                + mulDiv(_customTokenCount, JBConstants.MAX_REDEMPTION_RATE - _customRedemptionRate, _customTotalTokens),
+                + mulDiv(_customRedeemCount, JBConstants.MAX_REDEMPTION_RATE - _customRedemptionRate, _customTotalSupply),
             JBConstants.MAX_REDEMPTION_RATE
         );
 
@@ -295,7 +295,7 @@ contract TestRedeemHooks_Local is TestBaseWorkflow {
         vm.mockCall(
             _DATA_HOOK,
             abi.encodeWithSelector(IJBRulesetDataHook.beforeRedeemRecordedWith.selector),
-            abi.encode(_customRedemptionRate, _customTokenCount, _customTotalTokens, _specifications)
+            abi.encode(_customRedemptionRate, _customRedeemCount, _customTotalSupply, _specifications)
         );
 
         _terminal.redeemTokensOf({


### PR DESCRIPTION
# Description

- redeem hook can override perceived token weight being redeemed, and total supply.

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: