### PR TITLE
removed IJBController from a few interfaces for consistency

### DIFF
--- a/src/JBDeadline.sol
+++ b/src/JBDeadline.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.23;
 
-import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 import {JBApprovalStatus} from "./enums/JBApprovalStatus.sol";
@@ -12,7 +11,7 @@ import {JBRuleset} from "./structs/JBRuleset.sol";
 /// seconds before the current ruleset ends. In other words, rulesets must be queued before the deadline to take effect.
 /// @dev Project rulesets are stored in a queue. Rulesets take effect after the previous ruleset in the queue ends, and
 /// only if they are approved by the previous ruleset's approval hook.
-contract JBDeadline is ERC165, IJBRulesetApprovalHook {
+contract JBDeadline is IJBRulesetApprovalHook {
     //*********************************************************************//
     // --------------------------- custom errors ------------------------- //
     //*********************************************************************//
@@ -67,8 +66,8 @@ contract JBDeadline is ERC165, IJBRulesetApprovalHook {
     /// @dev See {IERC165-supportsInterface}.
     /// @param interfaceId The ID of the interface to check for adherence to.
     /// @return A flag indicating if this contract adheres to the specified interface.
-    function supportsInterface(bytes4 interfaceId) public view virtual override(ERC165, IERC165) returns (bool) {
-        return interfaceId == type(IJBRulesetApprovalHook).interfaceId || super.supportsInterface(interfaceId);
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return interfaceId == type(IJBRulesetApprovalHook).interfaceId || interfaceId == type(IERC165).interfaceId;
     }
 
     //*********************************************************************//

--- a/src/JBFeelessAddresses.sol
+++ b/src/JBFeelessAddresses.sol
@@ -2,13 +2,13 @@
 pragma solidity 0.8.23;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
-import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 import {IJBFeelessAddresses} from "./interfaces/IJBFeelessAddresses.sol";
 
 /// @notice Stores a list of addresses that shouldn't incur fees when sending or receiving payments.
-contract JBFeelessAddresses is Ownable, ERC165, IJBFeelessAddresses {
+contract JBFeelessAddresses is Ownable, IJBFeelessAddresses, IERC165  {
+
     //*********************************************************************//
     // --------------------- public stored properties -------------------- //
     //*********************************************************************//

--- a/src/JBFeelessAddresses.sol
+++ b/src/JBFeelessAddresses.sol
@@ -7,8 +7,7 @@ import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {IJBFeelessAddresses} from "./interfaces/IJBFeelessAddresses.sol";
 
 /// @notice Stores a list of addresses that shouldn't incur fees when sending or receiving payments.
-contract JBFeelessAddresses is Ownable, IJBFeelessAddresses, IERC165  {
-
+contract JBFeelessAddresses is Ownable, IJBFeelessAddresses, IERC165 {
     //*********************************************************************//
     // --------------------- public stored properties -------------------- //
     //*********************************************************************//

--- a/src/JBFundAccessLimits.sol
+++ b/src/JBFundAccessLimits.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.23;
 
-import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
-
 import {JBControlled} from "./abstract/JBControlled.sol";
 import {IJBDirectory} from "./interfaces/IJBDirectory.sol";
 import {IJBFundAccessLimits} from "./interfaces/IJBFundAccessLimits.sol";
@@ -11,7 +9,7 @@ import {JBFundAccessLimitGroup} from "./structs/JBFundAccessLimitGroup.sol";
 
 /// @notice Stores and manages terminal fund access limits for each project.
 /// @dev See the `JBFundAccessLimitGroup` struct to learn about payout limits and surplus allowances.
-contract JBFundAccessLimits is JBControlled, ERC165, IJBFundAccessLimits {
+contract JBFundAccessLimits is JBControlled, IJBFundAccessLimits {
     //*********************************************************************//
     // --------------------------- custom errors ------------------------- //
     //*********************************************************************//

--- a/src/JBPrices.sol
+++ b/src/JBPrices.sol
@@ -13,7 +13,7 @@ import {IJBProjects} from "./interfaces/IJBProjects.sol";
 
 /// @notice Manages and normalizes price feeds. Price feeds are contracts which return the "pricing currency" cost of 1
 /// "unit currency".
-contract JBPrices is Ownable, JBPermissioned, IJBPrices {
+contract JBPrices is JBPermissioned, Ownable, IJBPrices {
     //*********************************************************************//
     // --------------------------- custom errors ------------------------- //
     //*********************************************************************//

--- a/src/interfaces/IJBFundAccessLimits.sol
+++ b/src/interfaces/IJBFundAccessLimits.sol
@@ -1,12 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
-
 import {JBCurrencyAmount} from "./../structs/JBCurrencyAmount.sol";
 import {JBFundAccessLimitGroup} from "./../structs/JBFundAccessLimitGroup.sol";
 
-interface IJBFundAccessLimits is IERC165 {
+interface IJBFundAccessLimits {
     event SetFundAccessLimits(
         uint256 indexed rulesetId, uint256 indexed projectId, JBFundAccessLimitGroup limits, address caller
     );

--- a/src/interfaces/IJBRulesets.sol
+++ b/src/interfaces/IJBRulesets.sol
@@ -3,10 +3,9 @@ pragma solidity ^0.8.0;
 
 import {JBApprovalStatus} from "./../enums/JBApprovalStatus.sol";
 import {JBRuleset} from "./../structs/JBRuleset.sol";
-import {IJBControlled} from "./IJBControlled.sol";
 import {IJBRulesetApprovalHook} from "./IJBRulesetApprovalHook.sol";
 
-interface IJBRulesets is IJBControlled {
+interface IJBRulesets {
     event RulesetQueued(
         uint256 indexed rulesetId,
         uint256 indexed projectId,

--- a/src/interfaces/IJBSplits.sol
+++ b/src/interfaces/IJBSplits.sol
@@ -3,10 +3,9 @@ pragma solidity ^0.8.0;
 
 import {JBSplit} from "./../structs/JBSplit.sol";
 import {JBSplitGroup} from "./../structs/JBSplitGroup.sol";
-import {IJBControlled} from "./IJBControlled.sol";
 import {IJBProjects} from "./IJBProjects.sol";
 
-interface IJBSplits is IJBControlled {
+interface IJBSplits {
     event SetSplit(
         uint256 indexed projectId, uint256 indexed rulesetId, uint256 indexed group, JBSplit split, address caller
     );

--- a/src/interfaces/IJBTokens.sol
+++ b/src/interfaces/IJBTokens.sol
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {IJBControlled} from "./IJBControlled.sol";
 import {IJBToken} from "./IJBToken.sol";
 
-interface IJBTokens is IJBControlled {
+interface IJBTokens {
     event DeployERC20(
         uint256 indexed projectId, IJBToken indexed token, string name, string symbol, bytes32 salt, address caller
     );


### PR DESCRIPTION
# Description

made JBControllable interfaces consistent. FundAccessLimits, Rulesets, Tokens, and Splits should all have the same relationship to ERC165 and JBControllable.

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: