### PR TITLE
metadata pass between hooks

### DIFF
--- a/src/JBMultiTerminal.sol
+++ b/src/JBMultiTerminal.sol
@@ -1424,7 +1424,7 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
             uint256 payValue = tokenAmount.token == JBConstants.NATIVE_TOKEN ? specification.amount : 0;
 
             // Fulfill the specification.
-            specification.hook.afterPayRecordedWith{value: payValue}(context);
+            context.payerMetadata = specification.hook.afterPayRecordedWith{value: payValue}(context);
 
             emit HookAfterRecordPay(specification.hook, context, specification.amount, _msgSender());
         }
@@ -1513,7 +1513,7 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
             uint256 payValue = beneficiaryReclaimAmount.token == JBConstants.NATIVE_TOKEN ? specification.amount : 0;
 
             // Fulfill the specification.
-            specification.hook.afterRedeemRecordedWith{value: payValue}(context);
+            context.redeemerMetadata = specification.hook.afterRedeemRecordedWith{value: payValue}(context);
 
             emit HookAfterRecordRedeem(
                 specification.hook, context, specification.amount, specificationAmountFee, _msgSender()

--- a/src/JBMultiTerminal.sol
+++ b/src/JBMultiTerminal.sol
@@ -1392,7 +1392,8 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
             projectTokenCount: beneficiaryTokenCount,
             beneficiary: beneficiary,
             hookMetadata: bytes(""),
-            payerMetadata: metadata
+            payerMetadata: metadata,
+            specifications: specifications
         });
 
         // Keep a reference to the number of pay hook specifications to iterate through.
@@ -1467,7 +1468,8 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
             redemptionRate: redemptionRate,
             beneficiary: beneficiary,
             hookMetadata: "",
-            redeemerMetadata: metadata
+            redeemerMetadata: metadata,
+            specifications: specifications
         });
 
         // Keep a reference to the number of redeem hook specifications being iterated through.

--- a/src/interfaces/IJBPayHook.sol
+++ b/src/interfaces/IJBPayHook.sol
@@ -11,5 +11,6 @@ interface IJBPayHook is IERC165 {
     /// terminal store.
     /// @dev Critical business logic should be protected by appropriate access control.
     /// @param context The context passed in by the terminal, as a `JBAfterPayRecordedContext` struct.
-    function afterPayRecordedWith(JBAfterPayRecordedContext calldata context) external payable;
+    /// @return metadata The metadata to pass to the next redeem hook.
+    function afterPayRecordedWith(JBAfterPayRecordedContext calldata context) external payable returns (bytes memory metadata);
 }

--- a/src/interfaces/IJBRedeemHook.sol
+++ b/src/interfaces/IJBRedeemHook.sol
@@ -11,5 +11,6 @@ interface IJBRedeemHook is IERC165 {
     /// recorded in the terminal store.
     /// @dev Critical business logic should be protected by appropriate access control.
     /// @param context The context passed in by the terminal, as a `JBAfterRedeemRecordedContext` struct.
-    function afterRedeemRecordedWith(JBAfterRedeemRecordedContext calldata context) external payable;
+    /// @return metadata The metadata to pass to the next redeem hook.
+    function afterRedeemRecordedWith(JBAfterRedeemRecordedContext calldata context) external payable returns (bytes memory metadata);
 }

--- a/src/structs/JBAfterPayRecordedContext.sol
+++ b/src/structs/JBAfterPayRecordedContext.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import {JBPayHookSpecification} from "./JBPayHookSpecification.sol";
 import {JBTokenAmount} from "./JBTokenAmount.sol";
 
 /// @custom:member payer The address the payment originated from.
@@ -15,6 +16,7 @@ import {JBTokenAmount} from "./JBTokenAmount.sol";
 /// @custom:member beneficiary The address which receives any tokens this payment yields.
 /// @custom:member hookMetadata Extra data specified by the data hook, which is sent to the pay hook.
 /// @custom:member payerMetadata Extra data specified by the payer, which is sent to the pay hook.
+/// @custom:member specifications The specifications of pay hooks.
 struct JBAfterPayRecordedContext {
     address payer;
     uint256 projectId;
@@ -26,4 +28,5 @@ struct JBAfterPayRecordedContext {
     address beneficiary;
     bytes hookMetadata;
     bytes payerMetadata;
+    JBPayHookSpecification[] specifications;
 }

--- a/src/structs/JBAfterRedeemRecordedContext.sol
+++ b/src/structs/JBAfterRedeemRecordedContext.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import {JBRedeemHookSpecification} from "./JBRedeemHookSpecification.sol";
 import {JBTokenAmount} from "./JBTokenAmount.sol";
 
 /// @custom:member holder The holder of the tokens being redeemed.
@@ -16,6 +17,7 @@ import {JBTokenAmount} from "./JBTokenAmount.sol";
 /// @custom:member beneficiary The address the reclaimed amount will be sent to.
 /// @custom:member hookMetadata Extra data specified by the data hook, which is sent to the redeem hook.
 /// @custom:member redeemerMetadata Extra data specified by the redeemer, which is sent to the redeem hook.
+/// @custom:member specifications The specifications of redeem hooks.
 struct JBAfterRedeemRecordedContext {
     address holder;
     uint256 projectId;
@@ -27,4 +29,5 @@ struct JBAfterRedeemRecordedContext {
     address payable beneficiary;
     bytes hookMetadata;
     bytes redeemerMetadata;
+    JBRedeemHookSpecification[] specifications;
 }

--- a/test/TestPayHooks.sol
+++ b/test/TestPayHooks.sol
@@ -133,7 +133,8 @@ contract TestPayHooks_Local is TestBaseWorkflow {
                 projectTokenCount: mulDiv(_nativePayAmount, _DATA_HOOK_WEIGHT, 10 ** _NATIVE_TOKEN_DECIMALS),
                 beneficiary: _beneficiary,
                 hookMetadata: _hookMetadata,
-                payerMetadata: _PAYER_METADATA
+                payerMetadata: _PAYER_METADATA,
+                specifications: _specifications
             });
 
             // Mock the hook.

--- a/test/TestRedeemHooks.sol
+++ b/test/TestRedeemHooks.sol
@@ -156,7 +156,8 @@ contract TestRedeemHooks_Local is TestBaseWorkflow {
             redemptionRate: JBConstants.MAX_REDEMPTION_RATE,
             beneficiary: payable(address(this)),
             hookMetadata: "",
-            redeemerMetadata: ""
+            redeemerMetadata: "",
+            specifications: _specifications
         });
 
         // Mock the hook.
@@ -273,7 +274,8 @@ contract TestRedeemHooks_Local is TestBaseWorkflow {
             redemptionRate: _customRedemptionRate,
             beneficiary: payable(address(this)),
             hookMetadata: "",
-            redeemerMetadata: ""
+            redeemerMetadata: "",
+            specifications: _specifications
         });
 
         // Mock the hook.

--- a/test/units/static/JBMultiTerminal/TestPay.sol
+++ b/test/units/static/JBMultiTerminal/TestPay.sol
@@ -227,7 +227,8 @@ contract TestPay_Local is JBMultiTerminalSetup {
             projectTokenCount: _mintAmount,
             beneficiary: _bene,
             hookMetadata: bytes(""),
-            payerMetadata: bytes("")
+            payerMetadata: bytes(""),
+            specifications: hookSpecifications
         });
 
         // mock call to hook
@@ -310,7 +311,8 @@ contract TestPay_Local is JBMultiTerminalSetup {
             projectTokenCount: _mintAmount,
             beneficiary: _bene,
             hookMetadata: bytes(""),
-            payerMetadata: bytes("")
+            payerMetadata: bytes(""),
+            specifications: hookSpecifications
         });
 
         // mock call to hook (including msg.value)

--- a/test/units/static/JBMultiTerminal/TestRedeemTokensOf.sol
+++ b/test/units/static/JBMultiTerminal/TestRedeemTokensOf.sol
@@ -342,7 +342,8 @@ contract TestRedeemTokensOf_Local is JBMultiTerminalSetup {
             redemptionRate: _maxRedemptionRate,
             beneficiary: _bene,
             hookMetadata: "",
-            redeemerMetadata: ""
+            redeemerMetadata: "",
+            specifications: hookSpecifications
         });
 
         mockExpect(address(_mockHook), abi.encodeCall(IJBRedeemHook.afterRedeemRecordedWith, (context)), "");
@@ -448,7 +449,8 @@ contract TestRedeemTokensOf_Local is JBMultiTerminalSetup {
             redemptionRate: _maxRedemptionRate,
             beneficiary: _bene,
             hookMetadata: "",
-            redeemerMetadata: ""
+            redeemerMetadata: "",
+            specifications: hookSpecifications
         });
 
         mockExpect(address(_mockHook), abi.encodeCall(IJBRedeemHook.afterRedeemRecordedWith, (context)), "");


### PR DESCRIPTION
# Description

Pay/redeem hooks can pass metadata to subsequently called pay/redeem hooks as if the payer/redeemer were passing the metadata.

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: