### PR TITLE
feat: id getter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,5 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
       - name: Run local tests
         run: forge snapshot --fail-fast --summary --detailed
-      - name: Run fork tests
-        run: FOUNDRY_PROFILE=fork forge snapshot --fail-fast --summary --detailed
       - name: Check contract sizes
         run: forge build --sizes --skip SphinxUtils

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bananapus/core",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/JBMultiTerminal.sol
+++ b/src/JBMultiTerminal.sol
@@ -835,7 +835,7 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
         if (_msgSender() == address(this)) return amount;
 
         // The metadata ID is the first 4 bytes of this contract's address.
-        bytes4 metadataId = bytes4(bytes20(address(this)));
+        bytes4 metadataId = JBMetadataResolver.getId("allowance");
 
         // Unpack the allowance to use, if any, given by the frontend.
         (bool exists, bytes memory parsedMetadata) = JBMetadataResolver.getDataFor(metadataId, metadata);

--- a/src/JBMultiTerminal.sol
+++ b/src/JBMultiTerminal.sol
@@ -1087,7 +1087,7 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
                 beneficiary: beneficiary,
                 beneficiaryReclaimAmount: JBTokenAmount(
                     tokenToReclaim, reclaimAmount, accountingContext.decimals, accountingContext.currency
-                    ),
+                ),
                 specifications: hookSpecifications,
                 metadata: metadata
             });

--- a/src/JBMultiTerminal.sol
+++ b/src/JBMultiTerminal.sol
@@ -835,7 +835,7 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
         if (_msgSender() == address(this)) return amount;
 
         // The metadata ID is the first 4 bytes of this contract's address.
-        bytes4 metadataId = JBMetadataResolver.getId("allowance");
+        bytes4 metadataId = JBMetadataResolver.getId("permit2");
 
         // Unpack the allowance to use, if any, given by the frontend.
         (bool exists, bytes memory parsedMetadata) = JBMetadataResolver.getDataFor(metadataId, metadata);

--- a/src/libraries/JBMetadataResolver.sol
+++ b/src/libraries/JBMetadataResolver.sol
@@ -254,6 +254,10 @@ library JBMetadataResolver {
         }
     }
 
+    function getId(string memory _function) internal view returns (bytes4) {
+        return bytes4(bytes20(address(this)) ^ bytes20(keccak256(bytes(_function))));
+    }
+
     /// @notice Slice bytes from a start index to an end index.
     /// @param data The bytes array to slice
     /// @param start The start index to slice at.

--- a/src/libraries/JBMetadataResolver.sol
+++ b/src/libraries/JBMetadataResolver.sol
@@ -254,7 +254,16 @@ library JBMetadataResolver {
         }
     }
 
-    function getId(string memory _function) internal view returns (bytes4) {
+    /**
+     * @notice Returns an unique id following a suggested format
+     *         (`xor(address(this), functionality name)` where functionality name is a string
+     *         giving context to the id (Permit2, quoteForSwap, etc)
+     *
+     * @param _functionality   A string describing the functionality associated with the id
+     *
+     * @return id       The resulting id
+     */
+    function getId(string memory _functionality) internal view returns (bytes4) {
         return bytes4(bytes20(address(this)) ^ bytes20(keccak256(bytes(_function))));
     }
 

--- a/src/libraries/JBMetadataResolver.sol
+++ b/src/libraries/JBMetadataResolver.sol
@@ -264,7 +264,7 @@ library JBMetadataResolver {
      * @return id       The resulting id
      */
     function getId(string memory _functionality) internal view returns (bytes4) {
-        return bytes4(bytes20(address(this)) ^ bytes20(keccak256(bytes(_function))));
+        return bytes4(bytes20(address(this)) ^ bytes20(keccak256(bytes(_functionality))));
     }
 
     /// @notice Slice bytes from a start index to an end index.

--- a/src/libraries/JBMetadataResolver.sol
+++ b/src/libraries/JBMetadataResolver.sol
@@ -264,7 +264,21 @@ library JBMetadataResolver {
      * @return id       The resulting id
      */
     function getId(string memory _functionality) internal view returns (bytes4) {
-        return bytes4(bytes20(address(this)) ^ bytes20(keccak256(bytes(_functionality))));
+        return getId(_functionality, address(this));
+    }
+
+    /**
+     * @notice Returns an unique id following a suggested format
+     *         (`xor(address(this), functionality name)` where functionality name is a string
+     *         giving context to the id (Permit2, quoteForSwap, etc)
+     *
+     * @param _functionality   A string describing the functionality associated with the id
+     * @param _target          The target which will use the metadata
+     *
+     * @return id       The resulting id
+     */
+    function getId(string memory _functionality, address _target) internal view returns (bytes4) {
+        return bytes4(bytes20(_target) ^ bytes20(keccak256(bytes(_functionality))));
     }
 
     /// @notice Slice bytes from a start index to an end index.

--- a/src/libraries/JBMetadataResolver.sol
+++ b/src/libraries/JBMetadataResolver.sol
@@ -259,12 +259,12 @@ library JBMetadataResolver {
      *         (`xor(address(this), functionality name)` where functionality name is a string
      *         giving context to the id (Permit2, quoteForSwap, etc)
      *
-     * @param _functionality   A string describing the functionality associated with the id
+     * @param functionality   A string describing the functionality associated with the id
      *
      * @return id       The resulting id
      */
-    function getId(string memory _functionality) internal view returns (bytes4) {
-        return getId(_functionality, address(this));
+    function getId(string memory functionality) internal view returns (bytes4) {
+        return getId(functionality, address(this));
     }
 
     /**
@@ -272,13 +272,13 @@ library JBMetadataResolver {
      *         (`xor(address(this), functionality name)` where functionality name is a string
      *         giving context to the id (Permit2, quoteForSwap, etc)
      *
-     * @param _functionality   A string describing the functionality associated with the id
-     * @param _target          The target which will use the metadata
+     * @param functionality   A string describing the functionality associated with the id
+     * @param target          The target which will use the metadata
      *
      * @return id       The resulting id
      */
-    function getId(string memory _functionality, address _target) internal view returns (bytes4) {
-        return bytes4(bytes20(_target) ^ bytes20(keccak256(bytes(_functionality))));
+    function getId(string memory functionality, address target) internal view returns (bytes4) {
+        return bytes4(bytes20(target) ^ bytes20(keccak256(bytes(functionality))));
     }
 
     /// @notice Slice bytes from a start index to an end index.

--- a/test/TestPayHooks.sol
+++ b/test/TestPayHooks.sol
@@ -122,13 +122,13 @@ contract TestPayHooks_Local is TestBaseWorkflow {
                     _nativePayAmount,
                     _terminal.accountingContextForTokenOf(_projectId, JBConstants.NATIVE_TOKEN).decimals,
                     _terminal.accountingContextForTokenOf(_projectId, JBConstants.NATIVE_TOKEN).currency
-                    ),
+                ),
                 forwardedAmount: JBTokenAmount(
                     JBConstants.NATIVE_TOKEN,
                     _payHookAmounts[i],
                     _terminal.accountingContextForTokenOf(_projectId, JBConstants.NATIVE_TOKEN).decimals,
                     _terminal.accountingContextForTokenOf(_projectId, JBConstants.NATIVE_TOKEN).currency
-                    ),
+                ),
                 weight: _WEIGHT,
                 projectTokenCount: mulDiv(_nativePayAmount, _DATA_HOOK_WEIGHT, 10 ** _NATIVE_TOKEN_DECIMALS),
                 beneficiary: _beneficiary,

--- a/test/TestPermit2Terminal.sol
+++ b/test/TestPermit2Terminal.sol
@@ -142,7 +142,7 @@ contract TestPermit2Terminal_Local is TestBaseWorkflow {
         bytes4[] memory _ids = new bytes4[](1);
         bytes[] memory _datas = new bytes[](1);
         _datas[0] = abi.encode(permitData);
-        _ids[0] = _helper.getId("allowance", address(_terminal));
+        _ids[0] = _helper.getId("permit2", address(_terminal));
 
         // Setup: use the metadata library to encode.
         bytes memory _packedData = _helper.createMetadata(_ids, _datas);
@@ -208,7 +208,7 @@ contract TestPermit2Terminal_Local is TestBaseWorkflow {
         bytes4[] memory _ids = new bytes4[](1);
         bytes[] memory _datas = new bytes[](1);
         _datas[0] = abi.encode(permitData);
-        _ids[0] = _helper.getId("allowance", address(_terminal));
+        _ids[0] = _helper.getId("permit2", address(_terminal));
 
         // Setup: use the metadata library to encode.
         bytes memory _packedData = _helper.createMetadata(_ids, _datas);

--- a/test/TestPermit2Terminal.sol
+++ b/test/TestPermit2Terminal.sol
@@ -142,7 +142,7 @@ contract TestPermit2Terminal_Local is TestBaseWorkflow {
         bytes4[] memory _ids = new bytes4[](1);
         bytes[] memory _datas = new bytes[](1);
         _datas[0] = abi.encode(permitData);
-        _ids[0] = bytes4(bytes20(address(_terminal)));
+        _ids[0] = _helper.getId("allowance", address(_terminal));
 
         // Setup: use the metadata library to encode.
         bytes memory _packedData = _helper.createMetadata(_ids, _datas);
@@ -208,7 +208,7 @@ contract TestPermit2Terminal_Local is TestBaseWorkflow {
         bytes4[] memory _ids = new bytes4[](1);
         bytes[] memory _datas = new bytes[](1);
         _datas[0] = abi.encode(permitData);
-        _ids[0] = bytes4(bytes20((address(_terminal))));
+        _ids[0] = _helper.getId("allowance", address(_terminal));
 
         // Setup: use the metadata library to encode.
         bytes memory _packedData = _helper.createMetadata(_ids, _datas);

--- a/test/TestRedeemHooks.sol
+++ b/test/TestRedeemHooks.sol
@@ -146,13 +146,13 @@ contract TestRedeemHooks_Local is TestBaseWorkflow {
                 _halfPaid,
                 _terminal.accountingContextForTokenOf(_projectId, JBConstants.NATIVE_TOKEN).decimals,
                 _terminal.accountingContextForTokenOf(_projectId, JBConstants.NATIVE_TOKEN).currency
-                ),
+            ),
             forwardedAmount: JBTokenAmount(
                 JBConstants.NATIVE_TOKEN,
                 _halfPaid,
                 _terminal.accountingContextForTokenOf(_projectId, JBConstants.NATIVE_TOKEN).decimals,
                 _terminal.accountingContextForTokenOf(_projectId, JBConstants.NATIVE_TOKEN).currency
-                ),
+            ),
             redemptionRate: JBConstants.MAX_REDEMPTION_RATE,
             beneficiary: payable(address(this)),
             hookMetadata: "",
@@ -263,13 +263,13 @@ contract TestRedeemHooks_Local is TestBaseWorkflow {
                 _beneficiaryAmount,
                 _terminal.accountingContextForTokenOf(_projectId, JBConstants.NATIVE_TOKEN).decimals,
                 _terminal.accountingContextForTokenOf(_projectId, JBConstants.NATIVE_TOKEN).currency
-                ),
+            ),
             forwardedAmount: JBTokenAmount(
                 JBConstants.NATIVE_TOKEN,
                 _forwardedAmount,
                 _terminal.accountingContextForTokenOf(_projectId, JBConstants.NATIVE_TOKEN).decimals,
                 _terminal.accountingContextForTokenOf(_projectId, JBConstants.NATIVE_TOKEN).currency
-                ),
+            ),
             redemptionRate: _customRedemptionRate,
             beneficiary: payable(address(this)),
             hookMetadata: "",

--- a/test/helpers/MetadataResolverHelper.sol
+++ b/test/helpers/MetadataResolverHelper.sol
@@ -106,7 +106,7 @@ contract MetadataResolverHelper {
      *
      * @return id       The resulting id
      */
-    function getId(string memory _functionality) internal view returns (bytes4) {
+    function getId(string memory _functionality) public view returns (bytes4) {
         return JBMetadataResolver.getId(_functionality);
     }
 }

--- a/test/helpers/MetadataResolverHelper.sol
+++ b/test/helpers/MetadataResolverHelper.sol
@@ -96,4 +96,17 @@ contract MetadataResolverHelper {
     {
         return JBMetadataResolver.addToMetadata(originalMetadata, idToAdd, dataToAdd);
     }
+
+    /**
+     * @notice Returns an unique id following a suggested format
+     *         (`xor(address(this), functionality name)` where functionality name is a string
+     *         giving context to the id (Permit2, quoteForSwap, etc)
+     *
+     * @param _functionality   A string describing the functionality associated with the id
+     *
+     * @return id       The resulting id
+     */
+    function getId(string memory _functionality) internal view returns (bytes4) {
+        return JBMetadataResolver.getId(_functionality);
+    }
 }

--- a/test/helpers/MetadataResolverHelper.sol
+++ b/test/helpers/MetadataResolverHelper.sol
@@ -113,5 +113,4 @@ contract MetadataResolverHelper {
     function getId(string memory functionality, address target) public view returns (bytes4) {
         return JBMetadataResolver.getId(functionality, target);
     }
-
 }

--- a/test/helpers/MetadataResolverHelper.sol
+++ b/test/helpers/MetadataResolverHelper.sol
@@ -102,16 +102,16 @@ contract MetadataResolverHelper {
      *         (`xor(address(this), functionality name)` where functionality name is a string
      *         giving context to the id (Permit2, quoteForSwap, etc)
      *
-     * @param _functionality   A string describing the functionality associated with the id
+     * @param functionality   A string describing the functionality associated with the id
      *
      * @return id       The resulting id
      */
-    function getId(string memory _functionality) public view returns (bytes4) {
-        return JBMetadataResolver.getId(_functionality);
+    function getId(string memory functionality) public view returns (bytes4) {
+        return JBMetadataResolver.getId(functionality);
     }
 
-    function getId(string memory _functionality, address _target) public view returns (bytes4) {
-        return JBMetadataResolver.getId(_functionality, _target);
+    function getId(string memory functionality, address target) public view returns (bytes4) {
+        return JBMetadataResolver.getId(functionality, target);
     }
 
 }

--- a/test/helpers/MetadataResolverHelper.sol
+++ b/test/helpers/MetadataResolverHelper.sol
@@ -109,4 +109,9 @@ contract MetadataResolverHelper {
     function getId(string memory _functionality) public view returns (bytes4) {
         return JBMetadataResolver.getId(_functionality);
     }
+
+    function getId(string memory _functionality, address _target) public view returns (bytes4) {
+        return JBMetadataResolver.getId(_functionality, _target);
+    }
+
 }

--- a/test/units/static/JBMultiTerminal/TestAddToBalanceOf.sol
+++ b/test/units/static/JBMultiTerminal/TestAddToBalanceOf.sol
@@ -359,7 +359,7 @@ contract TestAddToBalanceOf_Local is JBMultiTerminalSetup {
         bytes4[] memory _ids = new bytes4[](1);
         bytes[] memory _datas = new bytes[](1);
         _datas[0] = abi.encode(permitData);
-        _ids[0] = bytes4(bytes20(address(_terminal)));
+        _ids[0] = _metadataHelper.getId("allowance", address(_terminal));
 
         // Setup: use the metadata library to encode.
         bytes memory _packedData = _metadataHelper.createMetadata(_ids, _datas);
@@ -412,7 +412,7 @@ contract TestAddToBalanceOf_Local is JBMultiTerminalSetup {
         bytes4[] memory _ids = new bytes4[](1);
         bytes[] memory _datas = new bytes[](1);
         _datas[0] = abi.encode(permitData);
-        _ids[0] = bytes4(bytes20(address(_terminal)));
+        _ids[0] = _metadataHelper.getId("allowance", _terminal)
 
         // Setup: use the metadata library to encode.
         bytes memory _packedData = _metadataHelper.createMetadata(_ids, _datas);

--- a/test/units/static/JBMultiTerminal/TestAddToBalanceOf.sol
+++ b/test/units/static/JBMultiTerminal/TestAddToBalanceOf.sol
@@ -359,7 +359,7 @@ contract TestAddToBalanceOf_Local is JBMultiTerminalSetup {
         bytes4[] memory _ids = new bytes4[](1);
         bytes[] memory _datas = new bytes[](1);
         _datas[0] = abi.encode(permitData);
-        _ids[0] = _metadataHelper.getId("allowance", address(_terminal));
+        _ids[0] = _metadataHelper.getId("permit2", address(_terminal));
 
         // Setup: use the metadata library to encode.
         bytes memory _packedData = _metadataHelper.createMetadata(_ids, _datas);
@@ -412,7 +412,7 @@ contract TestAddToBalanceOf_Local is JBMultiTerminalSetup {
         bytes4[] memory _ids = new bytes4[](1);
         bytes[] memory _datas = new bytes[](1);
         _datas[0] = abi.encode(permitData);
-        _ids[0] = _metadataHelper.getId("allowance", _terminal)
+        _ids[0] = _metadataHelper.getId("permit2", _terminal)
 
         // Setup: use the metadata library to encode.
         bytes memory _packedData = _metadataHelper.createMetadata(_ids, _datas);


### PR DESCRIPTION
# Description

Add a getter for id's, following a suggested format - `xor(address(this), functionality name)` where functionality name is a string giving context to the id (Permit2, quoteForSwap, etc).

## Limitations & risks

There is always an (extremely unlikely) chance of collision between 2 id's

# Check-list
- NA - Tests are covering the new feature
- [x] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [x] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- NA - I have run the test locally (and they pass) - 
- [x] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:
JBMetadataResolver
- Indirectly:
Any contract potentially using the metadataresolver lib