### PR TITLE
33Audits [H-03] createMetadata / addToMetadata

### DIFF
--- a/src/libraries/JBMetadataResolver.sol
+++ b/src/libraries/JBMetadataResolver.sol
@@ -116,6 +116,7 @@ library JBMetadataResolver {
         // There is something in the table offset, but not a valid entry - avoid overwriting
         if (originalMetadata.length < RESERVED_SIZE + ID_SIZE + 1) revert METADATA_TOO_SHORT();
 
+        // Make sure the data is padded to 32 bytes.
         if (dataToAdd.length < 32) revert DATA_NOT_PADDED();
 
         // Get the first data offset - upcast to avoid overflow (same for other offset)...

--- a/src/libraries/JBMetadataResolver.sol
+++ b/src/libraries/JBMetadataResolver.sol
@@ -116,6 +116,8 @@ library JBMetadataResolver {
         // There is something in the table offset, but not a valid entry - avoid overwriting
         if (originalMetadata.length < RESERVED_SIZE + ID_SIZE + 1) revert METADATA_TOO_SHORT();
 
+        if (dataToAdd.length < 32) revert DATA_NOT_PADDED();
+
         // Get the first data offset - upcast to avoid overflow (same for other offset)...
         uint256 firstOffset = uint8(originalMetadata[RESERVED_SIZE + ID_SIZE]);
 

--- a/src/libraries/JBMetadataResolver.sol
+++ b/src/libraries/JBMetadataResolver.sol
@@ -25,6 +25,7 @@ pragma solidity ^0.8.17;
  *            +-----------------------+
  */
 library JBMetadataResolver {
+    error DATA_NOT_PADDED();
     error LENGTH_MISMATCH();
     error METADATA_TOO_LONG();
     error METADATA_TOO_SHORT();
@@ -226,6 +227,8 @@ library JBMetadataResolver {
         // For each id, add it to the lookup table with the next free offset, then increment the offset by the data
         // length (rounded up)
         for (uint256 _i; _i < _ids.length; ++_i) {
+            if (_datas[_i].length < 32) revert DATA_NOT_PADDED();
+
             metadata = abi.encodePacked(metadata, _ids[_i], bytes1(uint8(_offset)));
             _offset += _datas[_i].length / JBMetadataResolver.WORD_SIZE;
 

--- a/test/TestMetadataParserLib.sol
+++ b/test/TestMetadataParserLib.sol
@@ -8,7 +8,7 @@ import /* {*} from */ "./helpers/TestBaseWorkflow.sol";
  *
  * @dev    These are a mixed collection of unit and integration tests.
  */
-contract JBDelegateMetadataLib_Test is Test {
+contract JBDelegateMetadataLib_Test_Local is Test {
     MetadataResolverHelper parser;
 
     /**
@@ -379,6 +379,23 @@ contract JBDelegateMetadataLib_Test is Test {
 
         // Below should revert.
         vm.expectRevert(abi.encodeWithSignature("LENGTH_MISMATCH()"));
+        parser.createMetadata(_ids, _datas);
+    }
+
+    /**
+     * @notice Test creating and parsing metadata of incorrect length.
+     */
+    function test_create__unpadded() external {
+        bytes4[] memory _ids = new bytes4[](1);
+        bytes[] memory _datas = new bytes[](1);
+
+        uint8 something = uint8(1);
+        bytes memory shortData = abi.encodePacked(something);
+
+        _ids[0] = bytes4(uint32(1));
+        _datas[0] = shortData;
+
+        vm.expectRevert(abi.encodeWithSignature("DATA_NOT_PADDED()"));
         parser.createMetadata(_ids, _datas);
     }
 }


### PR DESCRIPTION
# Description

Can confirm that data was previously malformed with length < 32. 

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [x] Tests are covering the new feature
- [x] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [x] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [x] I have run the test locally (and they pass)
- [x] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: