### PR TITLE
33Audits [M-05] createMetadata offset overflow

### DIFF
--- a/src/libraries/JBMetadataResolver.sol
+++ b/src/libraries/JBMetadataResolver.sol
@@ -230,7 +230,7 @@ library JBMetadataResolver {
             _offset += _datas[_i].length / JBMetadataResolver.WORD_SIZE;
 
             // Overflowing a bytes1?
-            if (_offset > 2 ** 8) revert METADATA_TOO_LONG();
+            if (_offset > 255) revert METADATA_TOO_LONG();
         }
 
         // Pad the table to a multiple of 32B

--- a/test/TestMetadataParserLib.sol
+++ b/test/TestMetadataParserLib.sol
@@ -88,7 +88,7 @@ contract JBDelegateMetadataLib_Test is Test {
      * @notice Test creating and parsing `uint`-only metadata.
      */
     function test_createAndParse_uint(uint256 _numberOfIds) external {
-        // Maximum 220 hooks with 1 word data (offset overflow if more).
+        // Maximum 219 hooks with 1 word data (offset overflow if more).
         _numberOfIds = bound(_numberOfIds, 1, 220);
 
         bytes4[] memory _ids = new bytes4[](_numberOfIds);
@@ -99,6 +99,7 @@ contract JBDelegateMetadataLib_Test is Test {
             _datas[_i] = abi.encode(type(uint256).max - _i);
         }
 
+        if (_numberOfIds == 220) vm.expectRevert(abi.encodeWithSignature("METADATA_TOO_LONG()"));
         bytes memory _metadata = parser.createMetadata(_ids, _datas);
 
         for (uint256 _i; _i < _ids.length; _i++) {


### PR DESCRIPTION
# Description

Just a proper overflow check considering the casting down to bytes1.

## Limitations & risks

@drgorillamd may have the best perspective on this. I'm unsure if the _offset calculations are thrown off by this change to the impl.

# Check-list
- [x] Tests are covering the new feature
- [x] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [x] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [x] I have run the test locally (and they pass)
- [x] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: