### PR TITLE
fix: references to removed `MIGRATE_CONTROLLER` permission

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,13 +18,13 @@
     "artifacts": "source ./.env && npx sphinx artifacts --org-id 'cltepuu9u0003j58rjtbd0hvu' --project-name 'nana-core'"
   },
   "dependencies": {
-    "@bananapus/permission-ids": "^0.0.7",
-    "@chainlink/contracts": "^1.1.0",
+    "@bananapus/permission-ids": "^0.0.8",
+    "@chainlink/contracts": "^1.1.1",
     "@openzeppelin/contracts": "^5.0.2",
     "@prb/math": "^4.0.2",
     "@uniswap/permit2": "github:Uniswap/permit2"
   },
   "devDependencies": {
-    "@sphinx-labs/plugins": "^0.31.12"
+    "@sphinx-labs/plugins": "^0.32.2"
   }
 }

--- a/src/JBController.sol
+++ b/src/JBController.sol
@@ -541,7 +541,7 @@ contract JBController is JBPermissioned, ERC2771Context, IJBController, IJBMigra
 
     /// @notice Migrate a project from this controller to another one.
     /// @dev Can only be called by the project's owner or an address with the owner's permission to
-    /// `MIGRATE_CONTROLLER`.
+    /// `SET_CONTROLLER`.
     /// @param projectId The ID of the project to migrate.
     /// @param to The controller to migrate the project to.
     function migrateController(uint256 projectId, IJBMigratable to) external virtual override {
@@ -549,7 +549,7 @@ contract JBController is JBPermissioned, ERC2771Context, IJBController, IJBMigra
         _requirePermissionFrom({
             account: PROJECTS.ownerOf(projectId),
             projectId: projectId,
-            permissionId: JBPermissionIds.MIGRATE_CONTROLLER
+            permissionId: JBPermissionIds.SET_CONTROLLER
         });
 
         // Get a reference to the project's ruleset.

--- a/test/units/static/JBController/TestMigrateController.sol
+++ b/test/units/static/JBController/TestMigrateController.sol
@@ -108,7 +108,7 @@ contract TestMigrateController_Local is JBControllerSetup {
         _;
     }
 
-    function test_Revert_When_CallerDoesNotHave_MIGRATE_CONTROLLER_Permission() external {
+    function test_Revert_When_CallerDoesNotHave_SET_CONTROLLER_Permission() external {
         // it should revert
         // mock ownerOf call
         bytes memory _ownerOfCall = abi.encodeCall(IERC721.ownerOf, (1));
@@ -118,7 +118,7 @@ contract TestMigrateController_Local is JBControllerSetup {
 
         // mock first permissions call
         bytes memory _permissionsCall = abi.encodeCall(
-            IJBPermissions.hasPermission, (address(this), address(1), 1, JBPermissionIds.MIGRATE_CONTROLLER, true, true)
+            IJBPermissions.hasPermission, (address(this), address(1), 1, JBPermissionIds.SET_CONTROLLER, true, true)
         );
         bytes memory _permissionsReturned = abi.encode(false);
 


### PR DESCRIPTION
# Description

*What does this PR: do, how, why?*

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: