### PR TITLE
Documentation improvements

### DIFF
--- a/src/JBController.sol
+++ b/src/JBController.sol
@@ -136,13 +136,13 @@ contract JBController is JBPermissioned, ERC2771Context, IJBController, IJBMigra
     /// @return ruleset The struct for the project's latest queued ruleset.
     /// @return metadata The ruleset's metadata.
     /// @return approvalStatus The ruleset's approval status.
-    function latestQueuedRulesetOf(uint256 projectId)
+    function latestQueuedOf(uint256 projectId)
         external
         view
         override
         returns (JBRuleset memory ruleset, JBRulesetMetadata memory metadata, JBApprovalStatus approvalStatus)
     {
-        (ruleset, approvalStatus) = RULESETS.latestQueuedRulesetOf(projectId);
+        (ruleset, approvalStatus) = RULESETS.latestQueuedOf(projectId);
         metadata = ruleset.expandMetadata();
     }
 

--- a/src/JBMultiTerminal.sol
+++ b/src/JBMultiTerminal.sol
@@ -60,8 +60,8 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
     //*********************************************************************//
 
     error ACCOUNTING_CONTEXT_ALREADY_SET();
-    error INADEQUATE_PAYOUT_AMOUNT();
-    error INADEQUATE_RECLAIM_AMOUNT();
+    error UNDER_MIN_TOKENS_PAID_OUT();
+    error UNDER_MIN_TOKENS_RECLAIMED();
     error UNDER_MIN_RETURNED_TOKENS();
     error NO_MSG_VALUE_ALLOWED();
     error OVERFLOW_ALERT();
@@ -74,8 +74,7 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
     //*********************************************************************//
 
     /// @notice This terminal's fee (as a fraction out of `JBConstants.MAX_FEE`).
-    /// @dev Fees are charged on payouts to addresses, surplus allowance usage, and redemptions if the redemption rate
-    /// is less than 100%.
+    /// @dev Fees are charged on payouts to addresses and surplus allowance usage, as well as redemptions while the redemption rate is less than 100%.
     uint256 public constant override FEE = 25; // 2.5%
 
     //*********************************************************************//
@@ -372,7 +371,7 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
         reclaimAmount = _redeemTokensOf(holder, projectId, tokenToReclaim, redeemCount, beneficiary, metadata);
 
         // The amount being reclaimed must be at least as much as was expected.
-        if (reclaimAmount < minTokensReclaimed) revert INADEQUATE_RECLAIM_AMOUNT();
+        if (reclaimAmount < minTokensReclaimed) revert UNDER_MIN_TOKENS_RECLAIMED();
     }
 
     /// @notice Sends payouts to a project's current payout split group, according to its ruleset, up to its current
@@ -409,7 +408,7 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
         amountPaidOut = _sendPayoutsOf(projectId, token, amount, currency);
 
         // The amount being paid out must be at least as much as was expected.
-        if (amountPaidOut < minTokensPaidOut) revert INADEQUATE_PAYOUT_AMOUNT();
+        if (amountPaidOut < minTokensPaidOut) revert UNDER_MIN_TOKENS_PAID_OUT();
     }
 
     /// @notice Allows a project to pay out funds from its surplus up to the current surplus allowance.
@@ -453,7 +452,7 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
         amountPaidOut = _useAllowanceOf(projectId, token, amount, currency, beneficiary, memo);
 
         // The amount being withdrawn must be at least as much as was expected.
-        if (amountPaidOut < minTokensPaidOut) revert INADEQUATE_PAYOUT_AMOUNT();
+        if (amountPaidOut < minTokensPaidOut) revert UNDER_MIN_TOKENS_PAID_OUT();
     }
 
     /// @notice Migrate a project's funds and operations to a new terminal that accepts the same token type.

--- a/src/JBMultiTerminal.sol
+++ b/src/JBMultiTerminal.sol
@@ -74,7 +74,8 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
     //*********************************************************************//
 
     /// @notice This terminal's fee (as a fraction out of `JBConstants.MAX_FEE`).
-    /// @dev Fees are charged on payouts to addresses and surplus allowance usage, as well as redemptions while the redemption rate is less than 100%.
+    /// @dev Fees are charged on payouts to addresses and surplus allowance usage, as well as redemptions while the
+    /// redemption rate is less than 100%.
     uint256 public constant override FEE = 25; // 2.5%
 
     //*********************************************************************//

--- a/src/JBPermissions.sol
+++ b/src/JBPermissions.sol
@@ -30,7 +30,8 @@ contract JBPermissions is IJBPermissions {
     /// @dev An account can give an operator permissions that only pertain to a specific project ID.
     /// @dev There is no project with a ID of 0 – this ID is a wildcard which gives an operator permissions pertaining
     /// to *all* project IDs on an account's behalf. Use this with caution.
-    /// @dev Permissions are stored in a packed `uint256`. Each of the first 255 bits can represent the on/off state of a permission. Applications can specify the significance of each permission ID.
+    /// @dev Permissions are stored in a packed `uint256`. Each of the first 255 bits can represent the on/off state of
+    /// a permission. Applications can specify the significance of each permission ID.
     /// @custom:param operator The address of the operator.
     /// @custom:param account The address of the account being operated on behalf of.
     /// @custom:param projectId The project ID the permissions are scoped to. An ID of 0 grants permissions across all

--- a/src/JBPermissions.sol
+++ b/src/JBPermissions.sol
@@ -30,8 +30,7 @@ contract JBPermissions is IJBPermissions {
     /// @dev An account can give an operator permissions that only pertain to a specific project ID.
     /// @dev There is no project with a ID of 0 – this ID is a wildcard which gives an operator permissions pertaining
     /// to *all* project IDs on an account's behalf. Use this with caution.
-    /// @dev Permissions are stored in a packed `uint256`. Each of the 256 bits represents the on/off state of a
-    /// permission. Applications can specify the significance of each permission ID.
+    /// @dev Permissions are stored in a packed `uint256`. Each of the first 255 bits can represent the on/off state of a permission. Applications can specify the significance of each permission ID.
     /// @custom:param operator The address of the operator.
     /// @custom:param account The address of the account being operated on behalf of.
     /// @custom:param projectId The project ID the permissions are scoped to. An ID of 0 grants permissions across all

--- a/src/JBRulesets.sol
+++ b/src/JBRulesets.sol
@@ -347,17 +347,24 @@ contract JBRulesets is JBControlled, IJBRulesets {
     /// @dev Only a project's current controller can queue its rulesets.
     /// @param projectId The ID of the project to queue the ruleset for.
     /// @param duration The number of seconds the ruleset lasts for, after which a new ruleset starts.
-    /// - A `duration` of 0 means this ruleset will remain active until the project owner queues a new ruleset. That new ruleset will start immediately.
-    /// - A ruleset with a non-zero `duration` applies until the duration ends – any newly queued rulesets will be *queued* to take effect afterwards.
-    /// - If a duration ends and no new rulesets are queued, the ruleset rolls over to a new ruleset with the same rules (except for a new `start` timestamp and a decayed `weight`).
-    /// @param weight A fixed point number with 18 decimals that contracts can use to base arbitrary calculations on. Payment terminals generally use this to determine how many tokens should be minted when the project is paid.
+    /// - A `duration` of 0 means this ruleset will remain active until the project owner queues a new ruleset. That new
+    /// ruleset will start immediately.
+    /// - A ruleset with a non-zero `duration` applies until the duration ends – any newly queued rulesets will be
+    /// *queued* to take effect afterwards.
+    /// - If a duration ends and no new rulesets are queued, the ruleset rolls over to a new ruleset with the same rules
+    /// (except for a new `start` timestamp and a decayed `weight`).
+    /// @param weight A fixed point number with 18 decimals that contracts can use to base arbitrary calculations on.
+    /// Payment terminals generally use this to determine how many tokens should be minted when the project is paid.
     /// @param decayRate A fraction (out of `JBConstants.MAX_DECAY_RATE`) to reduce the next ruleset's `weight` by.
     /// - If a ruleset specifies a non-zero `weight`, the `decayRate` does not apply.
     /// - If the `decayRate` is 0, the `weight` stays the same.
-    /// - If the `decayRate` is 10% of `JBConstants.MAX_DECAY_RATE`, next ruleset's `weight` will be 90% of the current one.
-    /// @param approvalHook A contract which dictates whether a proposed ruleset should be accepted or rejected. It can be used to constrain a project owner's ability to change ruleset parameters over time.
+    /// - If the `decayRate` is 10% of `JBConstants.MAX_DECAY_RATE`, next ruleset's `weight` will be 90% of the current
+    /// one.
+    /// @param approvalHook A contract which dictates whether a proposed ruleset should be accepted or rejected. It can
+    /// be used to constrain a project owner's ability to change ruleset parameters over time.
     /// @param metadata Arbitrary extra data to associate with this ruleset. This metadata is not used by `JBRulesets`.
-    /// @param mustStartAtOrAfter The earliest time the ruleset can start. The ruleset cannot start before this timestamp.
+    /// @param mustStartAtOrAfter The earliest time the ruleset can start. The ruleset cannot start before this
+    /// timestamp.
     /// @return The struct of the new ruleset.
     function queueFor(
         uint256 projectId,

--- a/src/JBRulesets.sol
+++ b/src/JBRulesets.sol
@@ -100,7 +100,7 @@ contract JBRulesets is JBControlled, IJBRulesets {
     /// @param projectId The ID of the project to get the latest queued ruleset of.
     /// @return ruleset The project's latest queued ruleset's struct.
     /// @return approvalStatus The approval hook's status for the ruleset.
-    function latestQueuedRulesetOf(uint256 projectId)
+    function latestQueuedOf(uint256 projectId)
         external
         view
         override
@@ -345,30 +345,19 @@ contract JBRulesets is JBControlled, IJBRulesets {
 
     /// @notice Queues the upcoming approvable ruleset for the specified project.
     /// @dev Only a project's current controller can queue its rulesets.
-    /// @param projectId The ID of the project the ruleset is being queued for.
-    /// @param duration The number of seconds the ruleset lasts for, after which a new ruleset will start. A
-    /// duration of 0 means that the ruleset will stay active until the project owner explicitly issues a
-    /// reconfiguration,
-    /// at which point a new ruleset will immediately start with the updated properties. If the duration is greater than
-    /// 0,
-    /// a project owner cannot make changes to a ruleset's parameters while it is active – any proposed changes will
-    /// apply
-    /// to the subsequent ruleset. If no changes are proposed, a ruleset rolls over to another one with the same
-    /// properties
-    /// but new `start` timestamp and a decayed `weight`.
-    /// @param weight A fixed point number with 18 decimals that contracts can use to base arbitrary calculations
-    /// on. For example, payment terminals can use this to determine how many tokens should be minted when a payment is
-    /// received.
-    /// @param decayRate A percent by how much the `weight` of the subsequent ruleset should be reduced, if the
-    /// project owner hasn't queued the subsequent ruleset with an explicit `weight`. If it's 0, each ruleset will have
-    /// equal weight. If the number is 90%, the next ruleset will have a 10% smaller weight. This weight is out of
-    /// `JBConstants.MAX_DECAY_RATE`.
-    /// @param approvalHook An address of a contract that says whether a proposed ruleset should be accepted or
-    /// rejected. It
-    /// can be used to create rules around how a project owner can change ruleset parameters over time.
+    /// @param projectId The ID of the project to queue the ruleset for.
+    /// @param duration The number of seconds the ruleset lasts for, after which a new ruleset starts.
+    /// - A `duration` of 0 means this ruleset will remain active until the project owner queues a new ruleset. That new ruleset will start immediately.
+    /// - A ruleset with a non-zero `duration` applies until the duration ends – any newly queued rulesets will be *queued* to take effect afterwards.
+    /// - If a duration ends and no new rulesets are queued, the ruleset rolls over to a new ruleset with the same rules (except for a new `start` timestamp and a decayed `weight`).
+    /// @param weight A fixed point number with 18 decimals that contracts can use to base arbitrary calculations on. Payment terminals generally use this to determine how many tokens should be minted when the project is paid.
+    /// @param decayRate A fraction (out of `JBConstants.MAX_DECAY_RATE`) to reduce the next ruleset's `weight` by.
+    /// - If a ruleset specifies a non-zero `weight`, the `decayRate` does not apply.
+    /// - If the `decayRate` is 0, the `weight` stays the same.
+    /// - If the `decayRate` is 10% of `JBConstants.MAX_DECAY_RATE`, next ruleset's `weight` will be 90% of the current one.
+    /// @param approvalHook A contract which dictates whether a proposed ruleset should be accepted or rejected. It can be used to constrain a project owner's ability to change ruleset parameters over time.
     /// @param metadata Arbitrary extra data to associate with this ruleset. This metadata is not used by `JBRulesets`.
-    /// @param mustStartAtOrAfter The earliest time the ruleset can start. The ruleset cannot start before this
-    /// timestamp.
+    /// @param mustStartAtOrAfter The earliest time the ruleset can start. The ruleset cannot start before this timestamp.
     /// @return The struct of the new ruleset.
     function queueFor(
         uint256 projectId,
@@ -555,7 +544,7 @@ contract JBRulesets is JBControlled, IJBRulesets {
         }
 
         // The time when the duration of the base ruleset's approval hook has finished.
-        // If the provided ruleset has no approval hook, return the current timestamp.
+        // If the provided ruleset has no approval hook, return 0 (no constraint on start time).
         uint256 timestampAfterApprovalHook = baseRuleset.approvalHook == IJBRulesetApprovalHook(address(0))
             ? 0
             : rulesetId + baseRuleset.approvalHook.DURATION();

--- a/src/interfaces/IJBController.sol
+++ b/src/interfaces/IJBController.sol
@@ -97,7 +97,7 @@ interface IJBController is IERC165, IJBProjectUriRegistry, IJBDirectoryAccessCon
         view
         returns (JBRuleset memory ruleset, JBRulesetMetadata memory metadata);
 
-    function latestQueuedRulesetOf(uint256 projectId)
+    function latestQueuedOf(uint256 projectId)
         external
         view
         returns (JBRuleset memory, JBRulesetMetadata memory metadata, JBApprovalStatus);

--- a/src/interfaces/IJBRulesets.sol
+++ b/src/interfaces/IJBRulesets.sol
@@ -24,7 +24,7 @@ interface IJBRulesets {
 
     function getRulesetOf(uint256 projectId, uint256 rulesetId) external view returns (JBRuleset memory);
 
-    function latestQueuedRulesetOf(uint256 projectId)
+    function latestQueuedOf(uint256 projectId)
         external
         view
         returns (JBRuleset memory ruleset, JBApprovalStatus approvalStatus);

--- a/src/structs/JBAccountingContext.sol
+++ b/src/structs/JBAccountingContext.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 /// @custom:member token The address of the token that accounting is being done with.
 /// @custom:member decimals The number of decimals expected in that token's fixed point accounting.
-/// @custom:member currency The currency that the token is priced in terms of.
+/// @custom:member currency The currency that the token is priced in terms of. By convention, this is `uint32(uint160(tokenAddress))` for tokens, or a constant ID from e.g. `JBCurrencyIds` for other currencies.
 struct JBAccountingContext {
     address token;
     uint8 decimals;

--- a/src/structs/JBAccountingContext.sol
+++ b/src/structs/JBAccountingContext.sol
@@ -3,7 +3,8 @@ pragma solidity ^0.8.0;
 
 /// @custom:member token The address of the token that accounting is being done with.
 /// @custom:member decimals The number of decimals expected in that token's fixed point accounting.
-/// @custom:member currency The currency that the token is priced in terms of. By convention, this is `uint32(uint160(tokenAddress))` for tokens, or a constant ID from e.g. `JBCurrencyIds` for other currencies.
+/// @custom:member currency The currency that the token is priced in terms of. By convention, this is
+/// `uint32(uint160(tokenAddress))` for tokens, or a constant ID from e.g. `JBCurrencyIds` for other currencies.
 struct JBAccountingContext {
     address token;
     uint8 decimals;

--- a/src/structs/JBCurrencyAmount.sol
+++ b/src/structs/JBCurrencyAmount.sol
@@ -2,7 +2,8 @@
 pragma solidity ^0.8.0;
 
 /// @custom:member amount The amount of the currency.
-/// @custom:member currency The currency. By convention, this is `uint32(uint160(tokenAddress))` for tokens, or a constant ID from e.g. `JBCurrencyIds` for other currencies.
+/// @custom:member currency The currency. By convention, this is `uint32(uint160(tokenAddress))` for tokens, or a
+/// constant ID from e.g. `JBCurrencyIds` for other currencies.
 struct JBCurrencyAmount {
     uint256 amount;
     uint256 currency;

--- a/src/structs/JBCurrencyAmount.sol
+++ b/src/structs/JBCurrencyAmount.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 /// @custom:member amount The amount of the currency.
-/// @custom:member currency The currency's index in `JBCurrencyIds`.
+/// @custom:member currency The currency. By convention, this is `uint32(uint160(tokenAddress))` for tokens, or a constant ID from e.g. `JBCurrencyIds` for other currencies.
 struct JBCurrencyAmount {
     uint256 amount;
     uint256 currency;

--- a/src/structs/JBRulesetMetadata.sol
+++ b/src/structs/JBRulesetMetadata.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.0;
 /// `JBConstants.MAX_RESERVED_RATE`.
 /// @custom:member redemptionRate The redemption rate of the ruleset. This number is a percentage calculated out of
 /// `JBConstants.MAX_REDEMPTION_RATE`.
-/// @custom:member baseCurrency The currency on which to base the ruleset's weight.
+/// @custom:member baseCurrency The currency on which to base the ruleset's weight. By convention, this is `uint32(uint160(tokenAddress))` for tokens, or a constant ID from e.g. `JBCurrencyIds` for other currencies.
 /// @custom:member pausePay A flag indicating if the pay functionality should be paused during the ruleset.
 /// @custom:member pauseCreditTransfers A flag indicating if the project token transfer functionality should be paused
 /// during the funding cycle.

--- a/src/structs/JBRulesetMetadata.sol
+++ b/src/structs/JBRulesetMetadata.sol
@@ -5,7 +5,8 @@ pragma solidity ^0.8.0;
 /// `JBConstants.MAX_RESERVED_RATE`.
 /// @custom:member redemptionRate The redemption rate of the ruleset. This number is a percentage calculated out of
 /// `JBConstants.MAX_REDEMPTION_RATE`.
-/// @custom:member baseCurrency The currency on which to base the ruleset's weight. By convention, this is `uint32(uint160(tokenAddress))` for tokens, or a constant ID from e.g. `JBCurrencyIds` for other currencies.
+/// @custom:member baseCurrency The currency on which to base the ruleset's weight. By convention, this is
+/// `uint32(uint160(tokenAddress))` for tokens, or a constant ID from e.g. `JBCurrencyIds` for other currencies.
 /// @custom:member pausePay A flag indicating if the pay functionality should be paused during the ruleset.
 /// @custom:member pauseCreditTransfers A flag indicating if the project token transfer functionality should be paused
 /// during the funding cycle.

--- a/src/structs/JBSplitGroup.sol
+++ b/src/structs/JBSplitGroup.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import {JBSplit} from "./JBSplit.sol";
 
-/// @custom:member groupId An identifier for the group.
+/// @custom:member groupId An identifier for the group. By convention, this ID is `uint256(uint160(tokenAddress))` for payouts and `1` for reserved tokens.
 /// @custom:member splits The splits in the group.
 struct JBSplitGroup {
     uint256 groupId;

--- a/src/structs/JBSplitGroup.sol
+++ b/src/structs/JBSplitGroup.sol
@@ -3,7 +3,8 @@ pragma solidity ^0.8.0;
 
 import {JBSplit} from "./JBSplit.sol";
 
-/// @custom:member groupId An identifier for the group. By convention, this ID is `uint256(uint160(tokenAddress))` for payouts and `1` for reserved tokens.
+/// @custom:member groupId An identifier for the group. By convention, this ID is `uint256(uint160(tokenAddress))` for
+/// payouts and `1` for reserved tokens.
 /// @custom:member splits The splits in the group.
 struct JBSplitGroup {
     uint256 groupId;

--- a/src/structs/JBSplitHookContext.sol
+++ b/src/structs/JBSplitHookContext.sol
@@ -7,7 +7,8 @@ import {JBSplit} from "./JBSplit.sol";
 /// @custom:member amount The amount being sent to the split hook, as a fixed point number.
 /// @custom:member decimals The number of decimals in the amount.
 /// @custom:member projectId The project the split belongs to.
-/// @custom:member groupId The group the split belongs to. By convention, this ID is `uint256(uint160(tokenAddress))` for payouts and `1` for reserved tokens.
+/// @custom:member groupId The group the split belongs to. By convention, this ID is `uint256(uint160(tokenAddress))`
+/// for payouts and `1` for reserved tokens.
 /// @custom:member split The split which specified the hook.
 struct JBSplitHookContext {
     address token;

--- a/src/structs/JBSplitHookContext.sol
+++ b/src/structs/JBSplitHookContext.sol
@@ -7,7 +7,7 @@ import {JBSplit} from "./JBSplit.sol";
 /// @custom:member amount The amount being sent to the split hook, as a fixed point number.
 /// @custom:member decimals The number of decimals in the amount.
 /// @custom:member projectId The project the split belongs to.
-/// @custom:member groupId The group the split belongs to.
+/// @custom:member groupId The group the split belongs to. By convention, this ID is `uint256(uint160(tokenAddress))` for payouts and `1` for reserved tokens.
 /// @custom:member split The split which specified the hook.
 struct JBSplitHookContext {
     address token;

--- a/src/structs/JBTokenAmount.sol
+++ b/src/structs/JBTokenAmount.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 /// @custom:member token The token the payment was made in.
 /// @custom:member value The amount of tokens that was paid, as a fixed point number.
 /// @custom:member decimals The number of decimals included in the value fixed point number.
-/// @custom:member currency The expected currency of the value.
+/// @custom:member currency The currency. By convention, this is `uint32(uint160(tokenAddress))` for tokens, or a constant ID from e.g. `JBCurrencyIds` for other currencies.
 struct JBTokenAmount {
     address token;
     uint256 value;

--- a/src/structs/JBTokenAmount.sol
+++ b/src/structs/JBTokenAmount.sol
@@ -4,7 +4,8 @@ pragma solidity ^0.8.0;
 /// @custom:member token The token the payment was made in.
 /// @custom:member value The amount of tokens that was paid, as a fixed point number.
 /// @custom:member decimals The number of decimals included in the value fixed point number.
-/// @custom:member currency The currency. By convention, this is `uint32(uint160(tokenAddress))` for tokens, or a constant ID from e.g. `JBCurrencyIds` for other currencies.
+/// @custom:member currency The currency. By convention, this is `uint32(uint160(tokenAddress))` for tokens, or a
+/// constant ID from e.g. `JBCurrencyIds` for other currencies.
 struct JBTokenAmount {
     address token;
     uint256 value;

--- a/test/trees/JBMultiTerminal/sendPayoutsOf.tree
+++ b/test/trees/JBMultiTerminal/sendPayoutsOf.tree
@@ -1,6 +1,6 @@
 TestPayoutsOf_Local
 ├── when amountPaidOut lt minTokensPaidOut
-│   └── it will revert INADEQUATE_PAYOUT_AMOUNT
+│   └── it will revert UNDER_MIN_TOKENS_PAID_OUT
 ├── when a split hook is configured
 │   ├── given the split hook is feeless
 │   │   └── it will not process a fee

--- a/test/trees/JBMultiTerminal/useAllowanceOf.tree
+++ b/test/trees/JBMultiTerminal/useAllowanceOf.tree
@@ -2,7 +2,7 @@ TestUseAllowanceOf_Local
 ├── when caller does not have permission
 │   └── it will revert UNAUTHORIZED
 ├── when amountPaidOut LT minTokensPaidOut
-│   └── it will revert INADEQUATE_PAYOUT_AMOUNT
+│   └── it will revert UNDER_MIN_TOKENS_PAID_OUT
 ├── when msgSender EQ feeless
 │   └── it will not incur fees
 ├── when msgSender DNEQ feeless

--- a/test/units/static/JBController/TestRulesetViews.sol
+++ b/test/units/static/JBController/TestRulesetViews.sol
@@ -61,7 +61,7 @@ contract TestRulesetViews_Local is JBControllerSetup {
         assertEq(metadata.reservedRate, data.expandMetadata().reservedRate);
     }
 
-    function test_latestQueuedRulesetOf() external {
+    function test_latestQueuedOf() external {
         // setup: return data
         JBRuleset memory data = JBRuleset({
             cycleNumber: 1,
@@ -76,14 +76,14 @@ contract TestRulesetViews_Local is JBControllerSetup {
         });
 
         // setup: mock call
-        bytes memory _encodedCall = abi.encodeCall(IJBRulesets.latestQueuedRulesetOf, (1));
+        bytes memory _encodedCall = abi.encodeCall(IJBRulesets.latestQueuedOf, (1));
         bytes memory _willReturn = abi.encode(data, JBApprovalStatus.Empty);
 
         mockExpect(address(rulesets), _encodedCall, _willReturn);
 
         // send
         (JBRuleset memory ruleset, JBRulesetMetadata memory metadata, JBApprovalStatus approvalStatus) =
-            _controller.latestQueuedRulesetOf(1);
+            _controller.latestQueuedOf(1);
 
         // check: return makes sense
         assertEq(data.duration, ruleset.duration);

--- a/test/units/static/JBMultiTerminal/TestRedeemTokensOf.sol
+++ b/test/units/static/JBMultiTerminal/TestRedeemTokensOf.sol
@@ -61,7 +61,7 @@ contract TestRedeemTokensOf_Local is JBMultiTerminalSetup {
     }
 
     function test_GivenRedeemCountLTMinTokensReclaimed() external whenCallerHasPermission {
-        // it will revert INADEQUATE_RECLAIM_AMOUNT
+        // it will revert UNDER_MIN_TOKENS_RECLAIMED
 
         uint256 reclaimAmount = 1e9;
         JBRedeemHookSpecification[] memory hookSpecifications = new JBRedeemHookSpecification[](0);
@@ -152,7 +152,7 @@ contract TestRedeemTokensOf_Local is JBMultiTerminalSetup {
 
         // mock feeless address check
         mockExpect(address(feelessAddresses), abi.encodeCall(IJBFeelessAddresses.isFeeless, (_bene)), abi.encode(true));
-        vm.expectRevert(abi.encodeWithSignature("INADEQUATE_RECLAIM_AMOUNT()"));
+        vm.expectRevert(abi.encodeWithSignature("UNDER_MIN_TOKENS_RECLAIMED()"));
         _terminal.redeemTokensOf(_holder, _projectId, _mockToken, _defaultAmount, 1e18, _bene, ""); // minReclaimAmount
             // = 1e18 but only 1e19 reclaimed
     }

--- a/test/units/static/JBMultiTerminal/TestSendPayoutsOf.sol
+++ b/test/units/static/JBMultiTerminal/TestSendPayoutsOf.sol
@@ -13,7 +13,7 @@ contract TestPayoutsOf_Local is JBMultiTerminalSetup {
     }
 
     function test_WhenAmountPaidOutLtMinTokensPaidOut() external {
-        // it will revert INADEQUATE_PAYOUT_AMOUNT
+        // it will revert UNDER_MIN_TOKENS_PAID_OUT
 
         // needed for terminal store mock call
         JBRuleset memory returnedRuleset = JBRuleset({
@@ -57,7 +57,7 @@ contract TestPayoutsOf_Local is JBMultiTerminalSetup {
             abi.encode(address(_terminal))
         );
 
-        vm.expectRevert(abi.encodeWithSignature("INADEQUATE_PAYOUT_AMOUNT()"));
+        vm.expectRevert(abi.encodeWithSignature("UNDER_MIN_TOKENS_PAID_OUT()"));
         _terminal.sendPayoutsOf(_projectId, address(0), 0, 0, 1);
     }
 

--- a/test/units/static/JBMultiTerminal/TestUseAllowanceOf.sol
+++ b/test/units/static/JBMultiTerminal/TestUseAllowanceOf.sol
@@ -16,7 +16,7 @@ contract TestUseAllowanceOf_Local is JBMultiTerminalSetup {
     } */
 
     function test_WhenAmountPaidOutLTMinTokensPaidOut() external {
-        // it will revert INADEQUATE_PAYOUT_AMOUNT
+        // it will revert UNDER_MIN_TOKENS_PAID_OUT
 
         // mock owner call
         mockExpect(address(projects), abi.encodeCall(IERC721.ownerOf, (_projectId)), abi.encode(address(this)));
@@ -48,7 +48,7 @@ contract TestUseAllowanceOf_Local is JBMultiTerminalSetup {
             address(feelessAddresses), abi.encodeCall(IJBFeelessAddresses.isFeeless, (address(this))), abi.encode(true)
         );
 
-        vm.expectRevert(abi.encodeWithSignature("INADEQUATE_PAYOUT_AMOUNT()"));
+        vm.expectRevert(abi.encodeWithSignature("UNDER_MIN_TOKENS_PAID_OUT()"));
         _terminal.useAllowanceOf(_projectId, address(0), 0, 0, 1, payable(address(this)), "");
     }
 

--- a/test/units/static/JBRulesets/TestLatestQueuedRulesetOf.sol
+++ b/test/units/static/JBRulesets/TestLatestQueuedRulesetOf.sol
@@ -117,8 +117,7 @@ contract TestLatestQueuedRulesetOf_Local is JBRulesetsSetup {
     function test_GivenTheRulesetIsBasedOnRulesetZero() external whenTheLatestRulesetIdDneqZero {
         // it will return JBApprovalStatus.Empty
 
-        (JBRuleset memory _latestRuleset, JBApprovalStatus _latestApprovalStatus) =
-            _rulesets.latestQueuedOf(_projectId);
+        (JBRuleset memory _latestRuleset, JBApprovalStatus _latestApprovalStatus) = _rulesets.latestQueuedOf(_projectId);
         assertEq(uint256(_latestApprovalStatus), 0);
         assertEq(_latestRuleset.id, block.timestamp);
     }
@@ -168,8 +167,7 @@ contract TestLatestQueuedRulesetOf_Local is JBRulesetsSetup {
             abi.encode(JBApprovalStatus.ApprovalExpected)
         );
 
-        (JBRuleset memory _latestRuleset, JBApprovalStatus _latestApprovalStatus) =
-            _rulesets.latestQueuedOf(_projectId);
+        (JBRuleset memory _latestRuleset, JBApprovalStatus _latestApprovalStatus) = _rulesets.latestQueuedOf(_projectId);
         assertEq(uint256(_latestApprovalStatus), 3); // 3 = enum ApprovalExpected of the basedOn ruleset
         assertEq(_latestRuleset.id, block.timestamp + 1); // second queued ruleset
     }
@@ -234,8 +232,7 @@ contract TestLatestQueuedRulesetOf_Local is JBRulesetsSetup {
             mustStartAtOrAfter: _mustStartAt
         });
 
-        (JBRuleset memory _latestRuleset, JBApprovalStatus _latestApprovalStatus) =
-            _rulesets.latestQueuedOf(_projectId);
+        (JBRuleset memory _latestRuleset, JBApprovalStatus _latestApprovalStatus) = _rulesets.latestQueuedOf(_projectId);
         assertEq(uint256(_latestApprovalStatus), 0); // 0 = enum Empty of the basedOn ruleset
         assertEq(_latestRuleset.id, block.timestamp + 1); // second queued ruleset
     }
@@ -243,8 +240,7 @@ contract TestLatestQueuedRulesetOf_Local is JBRulesetsSetup {
     function test_WhenTheLatestRulesetIdEqZero() external {
         // it will return empty ruleset and JBApprovalStatus.Empty
 
-        (JBRuleset memory _latestRuleset, JBApprovalStatus _latestApprovalStatus) =
-            _rulesets.latestQueuedOf(_projectId);
+        (JBRuleset memory _latestRuleset, JBApprovalStatus _latestApprovalStatus) = _rulesets.latestQueuedOf(_projectId);
         assertEq(uint256(_latestApprovalStatus), 0); // 0 = enum Empty of the basedOn ruleset
         assertEq(_latestRuleset.id, 0); // second queued ruleset
     }

--- a/test/units/static/JBRulesets/TestLatestQueuedRulesetOf.sol
+++ b/test/units/static/JBRulesets/TestLatestQueuedRulesetOf.sol
@@ -118,7 +118,7 @@ contract TestLatestQueuedRulesetOf_Local is JBRulesetsSetup {
         // it will return JBApprovalStatus.Empty
 
         (JBRuleset memory _latestRuleset, JBApprovalStatus _latestApprovalStatus) =
-            _rulesets.latestQueuedRulesetOf(_projectId);
+            _rulesets.latestQueuedOf(_projectId);
         assertEq(uint256(_latestApprovalStatus), 0);
         assertEq(_latestRuleset.id, block.timestamp);
     }
@@ -169,7 +169,7 @@ contract TestLatestQueuedRulesetOf_Local is JBRulesetsSetup {
         );
 
         (JBRuleset memory _latestRuleset, JBApprovalStatus _latestApprovalStatus) =
-            _rulesets.latestQueuedRulesetOf(_projectId);
+            _rulesets.latestQueuedOf(_projectId);
         assertEq(uint256(_latestApprovalStatus), 3); // 3 = enum ApprovalExpected of the basedOn ruleset
         assertEq(_latestRuleset.id, block.timestamp + 1); // second queued ruleset
     }
@@ -235,7 +235,7 @@ contract TestLatestQueuedRulesetOf_Local is JBRulesetsSetup {
         });
 
         (JBRuleset memory _latestRuleset, JBApprovalStatus _latestApprovalStatus) =
-            _rulesets.latestQueuedRulesetOf(_projectId);
+            _rulesets.latestQueuedOf(_projectId);
         assertEq(uint256(_latestApprovalStatus), 0); // 0 = enum Empty of the basedOn ruleset
         assertEq(_latestRuleset.id, block.timestamp + 1); // second queued ruleset
     }
@@ -244,7 +244,7 @@ contract TestLatestQueuedRulesetOf_Local is JBRulesetsSetup {
         // it will return empty ruleset and JBApprovalStatus.Empty
 
         (JBRuleset memory _latestRuleset, JBApprovalStatus _latestApprovalStatus) =
-            _rulesets.latestQueuedRulesetOf(_projectId);
+            _rulesets.latestQueuedOf(_projectId);
         assertEq(uint256(_latestApprovalStatus), 0); // 0 = enum Empty of the basedOn ruleset
         assertEq(_latestRuleset.id, 0); // second queued ruleset
     }


### PR DESCRIPTION
- Clarify `currency` and `groupId` field conventions throughout.
- More descriptive errors in `JBMultiTerminal`.
- Rename `latestQueuedRulesetOf(...)` -> `latestQueuedOf(...)` for consistency.
- Resolve [natspec issues noted by Chinmay](https://discord.com/channels/775859454780244028/1227188794638471219/1237344088479760385) in `JBRulesets`.
- Fix a few mistakes in the README examples.
- Several misc. improvements.