### PR TITLE
addAccountContext w currency and decimals

### DIFF
--- a/src/JBController.sol
+++ b/src/JBController.sol
@@ -1045,7 +1045,10 @@ contract JBController is JBPermissioned, ERC2771Context, IJBController, IJBMigra
             terminalConfig = terminalConfigs[i];
 
             // Add the accounting contexts for the specified tokens.
-            terminalConfig.terminal.addAccountingContextsFor(projectId, terminalConfig.accountingContextsToAccept);
+            terminalConfig.terminal.addAccountingContextsFor({
+                projectId: projectId,
+                accountingContexts: terminalConfig.accountingContextsToAccept
+            });
 
             // Add the terminal.
             terminals[i] = terminalConfig.terminal;

--- a/src/JBController.sol
+++ b/src/JBController.sol
@@ -1045,7 +1045,7 @@ contract JBController is JBPermissioned, ERC2771Context, IJBController, IJBMigra
             terminalConfig = terminalConfigs[i];
 
             // Add the accounting contexts for the specified tokens.
-            terminalConfig.terminal.addAccountingContextsFor(projectId, terminalConfig.tokensToAccept);
+            terminalConfig.terminal.addAccountingContextsFor(projectId, terminalConfig.accountingContextsToAccept);
 
             // Add the terminal.
             terminals[i] = terminalConfig.terminal;

--- a/src/JBMultiTerminal.sol
+++ b/src/JBMultiTerminal.sol
@@ -46,16 +46,6 @@ import {JBSplit} from "./structs/JBSplit.sol";
 import {JBSplitHookContext} from "./structs/JBSplitHookContext.sol";
 import {JBTokenAmount} from "./structs/JBTokenAmount.sol";
 
-library AC {
-    function isValid(JBAccountingContext memory accountingContext) external view returns (bool) {
-        return (accountingContext.token == JBConstants.NATIVE_TOKEN && accountingContext.decimals != 18)
-            || (
-                IERC165(accountingContext.token).supportsInterface(type(IERC20Metadata).interfaceId)
-                    && accountingContext.decimals != IERC20Metadata(accountingContext.token).decimals()
-            );
-    }
-}
-
 /// @notice `JBMultiTerminal` manages native/ERC-20 payments, redemptions, and surplus allowance usage for any number of
 /// projects. Terminals are the entry point for operations involving inflows and outflows of funds.
 contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
@@ -247,7 +237,7 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
     function _controllerOf(uint256 projectId) internal returns (IJBController) {
         return IJBController(address(DIRECTORY.controllerOf(projectId)));
     }
-    
+
     /// @notice Returns a flag indicating if interacting with an address should not incur fees.
     /// @param addr The address to check.
     /// @return A flag indicating if the address should not incur fees.

--- a/src/JBMultiTerminal.sol
+++ b/src/JBMultiTerminal.sol
@@ -684,15 +684,15 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
 
         // If there's a split hook set, transfer to its `process` function.
         if (split.hook != IJBSplitHook(address(0))) {
+            // Make sure that the address supports the split hook interface.
+            if (!split.hook.supportsInterface(type(IJBSplitHook).interfaceId)) {
+                revert("SPLIT_HOOK_INVALID");
+            }
+
             // This payout is eligible for a fee since the funds are leaving this contract and the split hook isn't a
             // feeless address.
             if (!_isFeeless(address(split.hook))) {
                 netPayoutAmount -= JBFees.feeAmountIn(amount, FEE);
-            }
-
-            // Make sure that the address supports the split hook interface.
-            if (!split.hook.supportsInterface(type(IJBSplitHook).interfaceId)) {
-                revert("SPLIT_HOOK_INVALID");
             }
 
             // Create the context to send to the split hook.

--- a/src/JBMultiTerminal.sol
+++ b/src/JBMultiTerminal.sol
@@ -566,7 +566,7 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
             account: PROJECTS.ownerOf(projectId),
             projectId: projectId,
             permissionId: JBPermissionIds.ADD_ACCOUNTING_CONTEXTS,
-            alsoGrantAccessIf: IJBController(_msgSender()) == _controllerOf(projectId)
+            alsoGrantAccessIf: _msgSender() == address(_controllerOf(projectId))
         });
 
         // Get a reference to the project's current ruleset.

--- a/src/JBMultiTerminal.sol
+++ b/src/JBMultiTerminal.sol
@@ -694,14 +694,15 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
             if (!split.hook.supportsInterface(type(IJBSplitHook).interfaceId)) {
                 revert("SPLIT_HOOK_INVALID");
             }
-                        // Create the context to send to the split hook.	
-            JBSplitHookContext memory context = JBSplitHookContext({	
-                token: token,	
-                amount: netPayoutAmount,	
-                decimals: _accountingContextForTokenOf[projectId][token].decimals,	
-                projectId: projectId,	
-                groupId: uint256(uint160(token)),	
-                split: split	
+
+            // Create the context to send to the split hook.
+            JBSplitHookContext memory context = JBSplitHookContext({
+                token: token,
+                amount: netPayoutAmount,
+                decimals: _accountingContextForTokenOf[projectId][token].decimals,
+                projectId: projectId,
+                groupId: uint256(uint160(token)),
+                split: split
             });
 
             // Trigger any inherited pre-transfer logic.

--- a/src/JBMultiTerminal.sol
+++ b/src/JBMultiTerminal.sol
@@ -247,7 +247,10 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
     function _controllerOf(uint256 projectId) internal returns (IJBController) {
         return IJBController(address(DIRECTORY.controllerOf(projectId)));
     }
-
+    
+    /// @notice Returns a flag indicating if interacting with an address should not incur fees.
+    /// @param addr The address to check.
+    /// @return A flag indicating if the address should not incur fees.
     function _isFeeless(address addr) internal view returns (bool) {
         return FEELESS_ADDRESSES.isFeeless(addr);
     }
@@ -644,7 +647,7 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
         require(msg.sender == address(this));
 
         if (address(feeTerminal) == address(0)) {
-            revert("E1");
+            revert("FEE_TERMINAL_NOT_FOUND");
         }
 
         // Trigger any inherited pre-transfer logic if funds will be transferred.
@@ -699,7 +702,7 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
 
             // Make sure that the address supports the split hook interface.
             if (!split.hook.supportsInterface(type(IJBSplitHook).interfaceId)) {
-                revert("E2");
+                revert("SPLIT_HOOK_INVALID");
             }
 
             // Trigger any inherited pre-transfer logic.
@@ -726,7 +729,7 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
             IJBTerminal terminal = DIRECTORY.primaryTerminalOf(split.projectId, token);
 
             // The project must have a terminal to send funds to.
-            if (terminal == IJBTerminal(address(0))) revert("E3");
+            if (terminal == IJBTerminal(address(0))) revert("RECIPIENT_PROJECT_TERMINAL_NOT_FOUND");
 
             // This payout is eligible for a fee if the funds are leaving this contract and the receiving terminal isn't
             // a feelss address.

--- a/src/interfaces/IJBSplits.sol
+++ b/src/interfaces/IJBSplits.sol
@@ -7,12 +7,12 @@ import {IJBProjects} from "./IJBProjects.sol";
 
 interface IJBSplits {
     event SetSplit(
-        uint256 indexed projectId, uint256 indexed rulesetId, uint256 indexed group, JBSplit split, address caller
+        uint256 indexed projectId, uint256 indexed rulesetId, uint256 indexed groupId, JBSplit split, address caller
     );
 
     function FALLBACK_RULESET_ID() external view returns (uint256);
 
-    function splitsOf(uint256 projectId, uint256 rulesetId, uint256 group) external view returns (JBSplit[] memory);
+    function splitsOf(uint256 projectId, uint256 rulesetId, uint256 groupId) external view returns (JBSplit[] memory);
 
     function setSplitGroupsOf(uint256 projectId, uint256 rulesetId, JBSplitGroup[] memory splitGroups) external;
 }

--- a/src/interfaces/IJBTerminal.sol
+++ b/src/interfaces/IJBTerminal.sol
@@ -17,9 +17,7 @@ interface IJBTerminal is IERC165 {
         uint256 indexed projectId, uint256 amount, uint256 unlockedFees, string memo, bytes metadata, address caller
     );
 
-    event SetAccountingContext(
-        uint256 indexed projectId, address indexed token, JBAccountingContext context, address caller
-    );
+    event SetAccountingContext(uint256 indexed projectId, JBAccountingContext context, address caller);
 
     event Pay(
         uint256 indexed rulesetId,
@@ -52,7 +50,7 @@ interface IJBTerminal is IERC165 {
 
     function migrateBalanceOf(uint256 projectId, address token, IJBTerminal to) external returns (uint256 balance);
 
-    function addAccountingContextsFor(uint256 projectId, address[] calldata tokens) external;
+    function addAccountingContextsFor(uint256 projectId, JBAccountingContext[] calldata accountingContexts) external;
 
     function pay(
         uint256 projectId,

--- a/src/structs/JBTerminalConfig.sol
+++ b/src/structs/JBTerminalConfig.sol
@@ -2,10 +2,11 @@
 pragma solidity ^0.8.0;
 
 import {IJBTerminal} from "./../interfaces/IJBTerminal.sol";
+import {JBAccountingContext} from "./JBAccountingContext.sol";
 
 /// @custom:member terminal The terminal to configure.
-/// @custom:member acceptedTokens The tokens to accept from the terminal.
+/// @custom:member accountingContextsToAccept The accounting contexts to accept from the terminal.
 struct JBTerminalConfig {
     IJBTerminal terminal;
-    address[] tokensToAccept;
+    JBAccountingContext[] accountingContextsToAccept;
 }


### PR DESCRIPTION
# Description

Adding accounting contexts now allows clients to specify how many decimals the token does its accounting with and what currency it corresponds to. This puts more responsibility onto clients to get these values right, while allowing the protocol to adapt to edge cases better. These edge cases are 1) erc20 doesnt expose `decimals` function, and 2) two tokens share a first 4 bytes therefor have clashing currencies. 

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: