### PR TITLE
beneficiaryTokenCount takes BBH into account.

### DIFF
--- a/src/JBMultiTerminal.sol
+++ b/src/JBMultiTerminal.sol
@@ -688,8 +688,7 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
         // Set the beneficiary token count.
         if (beneficiaryBalanceAfter <= beneficiaryBalanceBefore) {
             beneficiaryTokenCount = 0;
-        }
-        else {
+        } else {
             beneficiaryTokenCount = beneficiaryBalanceAfter - beneficiaryBalanceBefore;
         }
 
@@ -1028,7 +1027,6 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
                 metadata: metadata
             });
         } else {
-
             // Trigger any inherited pre-transfer logic.
             // slither-disable-next-line reentrancy-events
             _beforeTransferTo({to: address(terminal), token: token, amount: amount});
@@ -1650,8 +1648,12 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
 
         // Send payouts to the splits and get a reference to the amount left over after the splits have been paid.
         // Also get a reference to the amount which was paid out to splits that is eligible for fees.
-        (uint256 leftoverPayoutAmount, uint256 amountEligibleForFees) =
-            _sendPayoutsToSplitGroupOf({projectId: projectId, token: token, rulesetId: ruleset.id, amount: amountPaidOut});
+        (uint256 leftoverPayoutAmount, uint256 amountEligibleForFees) = _sendPayoutsToSplitGroupOf({
+            projectId: projectId,
+            token: token,
+            rulesetId: ruleset.id,
+            amount: amountPaidOut
+        });
 
         // Take the fee.
         uint256 feeTaken = _takeFeeFrom({
@@ -1668,7 +1670,8 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
         // Send any leftover funds to the project owner and update the net leftover (which is returned) accordingly.
         if (leftoverPayoutAmount != 0) {
             // Subtract the fee from the net leftover amount.
-            netLeftoverPayoutAmount = leftoverPayoutAmount - JBFees.feeAmountIn({amount: leftoverPayoutAmount, feePercent: FEE});
+            netLeftoverPayoutAmount =
+                leftoverPayoutAmount - JBFees.feeAmountIn({amount: leftoverPayoutAmount, feePercent: FEE});
 
             // Transfer the amount to the project owner.
             _transferFrom({from: address(this), to: projectOwner, token: token, amount: netLeftoverPayoutAmount});

--- a/src/JBMultiTerminal.sol
+++ b/src/JBMultiTerminal.sol
@@ -1657,7 +1657,7 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
         if (leftoverPayoutAmount != 0) {
             if (!_isFeeless(projectOwner)) {
                 amountEligibleForFees += leftoverPayoutAmount;
-                leftoverPayoutAmount -=  JBFees.feeAmountIn({amount: leftoverPayoutAmount, feePercent: FEE});
+                leftoverPayoutAmount -= JBFees.feeAmountIn({amount: leftoverPayoutAmount, feePercent: FEE});
             }
 
             // Transfer the amount to the project owner.

--- a/src/JBMultiTerminal.sol
+++ b/src/JBMultiTerminal.sol
@@ -686,7 +686,7 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
         uint256 beneficiaryBalanceAfter = tokens.totalBalanceOf({holder: beneficiary, projectId: projectId});
 
         // Set the beneficiary token count.
-        if (beneficiaryBalanceAfter < beneficiaryBalanceBefore) {
+        if (beneficiaryBalanceAfter <= beneficiaryBalanceBefore) {
             beneficiaryTokenCount = 0;
         }
         else {

--- a/src/JBMultiTerminal.sol
+++ b/src/JBMultiTerminal.sol
@@ -686,8 +686,9 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
         uint256 beneficiaryBalanceAfter = tokens.totalBalanceOf({holder: beneficiary, projectId: projectId});
 
         // Set the beneficiary token count.
-        beneficiaryTokenCount =
-            beneficiaryBalanceAfter <= beneficiaryBalanceBefore ? 0 : beneficiaryBalanceAfter - beneficiaryBalanceBefore;
+        if (beneficiaryBalanceAfter > beneficiaryBalanceBefore) {
+            beneficiaryTokenCount = beneficiaryBalanceAfter - beneficiaryBalanceBefore;
+        }
 
         // The token count for the beneficiary must be greater than or equal to the specified minimum.
         if (beneficiaryTokenCount < minReturnedTokens) {

--- a/src/JBMultiTerminal.sol
+++ b/src/JBMultiTerminal.sol
@@ -686,11 +686,8 @@ contract JBMultiTerminal is JBPermissioned, ERC2771Context, IJBMultiTerminal {
         uint256 beneficiaryBalanceAfter = tokens.totalBalanceOf({holder: beneficiary, projectId: projectId});
 
         // Set the beneficiary token count.
-        if (beneficiaryBalanceAfter <= beneficiaryBalanceBefore) {
-            beneficiaryTokenCount = 0;
-        } else {
-            beneficiaryTokenCount = beneficiaryBalanceAfter - beneficiaryBalanceBefore;
-        }
+        beneficiaryTokenCount =
+            beneficiaryBalanceAfter <= beneficiaryBalanceBefore ? 0 : beneficiaryBalanceAfter - beneficiaryBalanceBefore;
 
         // The token count for the beneficiary must be greater than or equal to the specified minimum.
         if (beneficiaryTokenCount < minReturnedTokens) {

--- a/src/interfaces/IJBTerminal.sol
+++ b/src/interfaces/IJBTerminal.sol
@@ -26,7 +26,7 @@ interface IJBTerminal is IERC165 {
         address payer,
         address beneficiary,
         uint256 amount,
-        uint256 beneficiaryTokenCount,
+        uint256 newlyIssuedTokenCount,
         string memo,
         bytes metadata,
         address caller

--- a/src/structs/JBAfterPayRecordedContext.sol
+++ b/src/structs/JBAfterPayRecordedContext.sol
@@ -11,7 +11,7 @@ import {JBTokenAmount} from "./JBTokenAmount.sol";
 /// @custom:member forwardedAmount The token amount being forwarded to the pay hook. Includes the token
 /// being paid, the value, the number of decimals included, and the currency of the amount.
 /// @custom:member weight The current ruleset's weight (used to determine how many tokens should be minted).
-/// @custom:member projectTokenCount The number of project tokens minted for the beneficiary.
+/// @custom:member newlyIssuedTokenCount The number of project tokens minted for the beneficiary.
 /// @custom:member beneficiary The address which receives any tokens this payment yields.
 /// @custom:member hookMetadata Extra data specified by the data hook, which is sent to the pay hook.
 /// @custom:member payerMetadata Extra data specified by the payer, which is sent to the pay hook.
@@ -22,7 +22,7 @@ struct JBAfterPayRecordedContext {
     JBTokenAmount amount;
     JBTokenAmount forwardedAmount;
     uint256 weight;
-    uint256 projectTokenCount;
+    uint256 newlyIssuedTokenCount;
     address beneficiary;
     bytes hookMetadata;
     bytes payerMetadata;

--- a/test/TestPayHooks.sol
+++ b/test/TestPayHooks.sol
@@ -140,7 +140,7 @@ contract TestPayHooks_Local is TestBaseWorkflow {
                     _payHookAmounts[i]
                 ),
                 weight: _WEIGHT,
-                projectTokenCount: mulDiv(_nativePayAmount, _DATA_HOOK_WEIGHT, 10 ** _NATIVE_TOKEN_DECIMALS),
+                newlyIssuedTokenCount: mulDiv(_nativePayAmount, _DATA_HOOK_WEIGHT, 10 ** _NATIVE_TOKEN_DECIMALS),
                 beneficiary: _beneficiary,
                 hookMetadata: _hookMetadata,
                 payerMetadata: _PAYER_METADATA

--- a/test/helpers/JBTest.sol
+++ b/test/helpers/JBTest.sol
@@ -16,6 +16,17 @@ contract JBTest is Test {
         vm.expectCall(_where, _encodedCall);
     }
 
+    // Multiple calls with different return values
+    function mockExpectSubsequent(address _where, bytes memory _encodedCall, bytes[] memory _returns) public {
+        // Mocks calls with different return values
+        vm.mockCalls(_where, _encodedCall, _returns);
+
+        // Will check that multiple calls are made
+        for (uint256 i = 0; i < _returns.length; i++) {
+            vm.expectCall(_where, _encodedCall);
+        }
+    }
+
     function generateFriendlyRuleset() public view returns (JBRuleset memory) {
         JBRulesetMetadata memory _rulesMetadata = JBRulesetMetadata({
             reservedPercent: JBConstants.MAX_RESERVED_PERCENT,

--- a/test/units/static/JBMultiTerminal/TestPay.sol
+++ b/test/units/static/JBMultiTerminal/TestPay.sol
@@ -136,6 +136,15 @@ contract TestPay_Local is JBMultiTerminalSetup {
             abi.encode(returnedRuleset, 0, hookSpecifications)
         );
 
+        // mock call to the "controller" which is actually this contract for mocking purposes
+        mockExpect(
+            address(directory), abi.encodeCall(IJBDirectory.controllerOf, (_projectId)), abi.encode(address(this))
+        );
+
+        mockExpect(address(this), abi.encodeCall(IJBController.TOKENS, ()), abi.encode(address(this)));
+
+        mockExpect(address(this), abi.encodeCall(IJBTokens.totalBalanceOf, (_bene, _projectId)), abi.encode(0));
+
         vm.expectRevert(abi.encodeWithSelector(JBMultiTerminal.JBMultiTerminal_UnderMinReturnedTokens.selector, 0, 1));
         _terminal.pay{value: 1e18}({
             projectId: _projectId,
@@ -182,6 +191,19 @@ contract TestPay_Local is JBMultiTerminalSetup {
             address(this),
             abi.encodeCall(IJBController.mintTokensOf, (_projectId, _mintAmount, _bene, "", true)),
             abi.encode(_mintAmount)
+        );
+
+        // mock call to the "controller" which is actually this contract for mocking purposes
+        mockExpect(address(this), abi.encodeCall(IJBController.TOKENS, ()), abi.encode(address(this)));
+
+        // Data for subsequent calls made for balance checks
+        bytes[] memory subsequentReturns = new bytes[](2);
+        subsequentReturns[0] = abi.encode(0);
+        subsequentReturns[1] = abi.encode(_mintAmount);
+
+        // Mock subsequent calls made for balance checks
+        mockExpectSubsequent(
+            address(this), abi.encodeCall(IJBTokens.totalBalanceOf, (_bene, _projectId)), subsequentReturns
         );
 
         vm.expectEmit();
@@ -294,6 +316,19 @@ contract TestPay_Local is JBMultiTerminalSetup {
         vm.expectEmit();
         emit IJBTerminal.HookAfterRecordPay(_mockHook, context, _defaultAmount, address(this));
 
+        // mock call to the "controller" which is actually this contract for mocking purposes
+        mockExpect(address(this), abi.encodeCall(IJBController.TOKENS, ()), abi.encode(address(this)));
+
+        // Data for subsequent calls made for balance checks
+        bytes[] memory subsequentReturns = new bytes[](2);
+        subsequentReturns[0] = abi.encode(0);
+        subsequentReturns[1] = abi.encode(_mintAmount);
+
+        // Mock subsequent calls made for balance checks
+        mockExpectSubsequent(
+            address(this), abi.encodeCall(IJBTokens.totalBalanceOf, (_bene, _projectId)), subsequentReturns
+        );
+
         _terminal.pay({
             projectId: _projectId,
             token: address(_mockToken),
@@ -360,6 +395,19 @@ contract TestPay_Local is JBMultiTerminalSetup {
         // mock call to hook (including msg.value)
         mockExpect(address(_mockHook), abi.encodeCall(IJBPayHook.afterPayRecordedWith, (context)), "");
 
+        // mock call to the "controller" which is actually this contract for mocking purposes
+        mockExpect(address(this), abi.encodeCall(IJBController.TOKENS, ()), abi.encode(address(this)));
+
+        // Data for subsequent calls made for balance checks
+        bytes[] memory subsequentReturns = new bytes[](2);
+        subsequentReturns[0] = abi.encode(0);
+        subsequentReturns[1] = abi.encode(_mintAmount);
+
+        // Mock subsequent calls made for balance checks
+        mockExpectSubsequent(
+            address(this), abi.encodeCall(IJBTokens.totalBalanceOf, (_bene, _projectId)), subsequentReturns
+        );
+
         vm.expectEmit();
         emit IJBTerminal.Pay(
             returnedRuleset.id,
@@ -391,6 +439,15 @@ contract TestPay_Local is JBMultiTerminalSetup {
     function test_WhenTheProjectDNHAccountingContextForTheToken() external {
         // it will revert TOKEN_NOT_ACCEPTED
 
+        // mock call to the "controller" which is actually this contract for mocking purposes
+        mockExpect(
+            address(directory), abi.encodeCall(IJBDirectory.controllerOf, (_projectId)), abi.encode(address(this))
+        );
+
+        mockExpect(address(this), abi.encodeCall(IJBController.TOKENS, ()), abi.encode(address(this)));
+
+        mockExpect(address(this), abi.encodeCall(IJBTokens.totalBalanceOf, (_bene, _projectId)), abi.encode(0));
+
         vm.expectRevert(abi.encodeWithSelector(JBMultiTerminal.JBMultiTerminal_TokenNotAccepted.selector, _native));
         _terminal.pay{value: 1e18}({
             projectId: _projectId,
@@ -410,6 +467,16 @@ contract TestPay_Local is JBMultiTerminalSetup {
 
     function test_WhenTheTerminalsTokenEqNativeTokenAndMsgvalueEqZero() external {
         // it will revert NO_MSG_VALUE_ALLOWED
+
+        // mock call to the "controller" which is actually this contract for mocking purposes
+        mockExpect(
+            address(directory), abi.encodeCall(IJBDirectory.controllerOf, (_projectId)), abi.encode(address(this))
+        );
+
+        // mock call to the "controller" which is actually this contract for mocking purposes
+        mockExpect(address(this), abi.encodeCall(IJBController.TOKENS, ()), abi.encode(address(this)));
+
+        mockExpect(address(this), abi.encodeCall(IJBTokens.totalBalanceOf, (_bene, _projectId)), abi.encode(0));
 
         vm.expectRevert(abi.encodeWithSelector(JBMultiTerminal.JBMultiTerminal_TokenNotAccepted.selector, _native));
         _terminal.pay{value: 0}({
@@ -449,6 +516,19 @@ contract TestPay_Local is JBMultiTerminalSetup {
                 IJBTerminalStore.recordPaymentFrom, (address(_terminal), tokenAmount, _projectId, _bene, bytes(""))
             ),
             abi.encode(returnedRuleset, 0, hookSpecifications)
+        );
+
+        // mock call to the "controller" which is actually this contract for mocking purposes
+        mockExpect(address(this), abi.encodeCall(IJBController.TOKENS, ()), abi.encode(address(this)));
+
+        // Data for subsequent calls made for balance checks
+        bytes[] memory subsequentReturns = new bytes[](2);
+        subsequentReturns[0] = abi.encode(0);
+        subsequentReturns[1] = abi.encode(0);
+
+        // Mock subsequent calls made for balance checks
+        mockExpectSubsequent(
+            address(this), abi.encodeCall(IJBTokens.totalBalanceOf, (_bene, _projectId)), subsequentReturns
         );
 
         vm.deal(address(_terminal), _defaultAmount);

--- a/test/units/static/JBMultiTerminal/TestPay.sol
+++ b/test/units/static/JBMultiTerminal/TestPay.sol
@@ -269,7 +269,7 @@ contract TestPay_Local is JBMultiTerminalSetup {
             amount: tokenAmount,
             forwardedAmount: tokenAmount,
             weight: returnedRuleset.weight,
-            projectTokenCount: _mintAmount,
+            newlyIssuedTokenCount: _mintAmount,
             beneficiary: _bene,
             hookMetadata: bytes(""),
             payerMetadata: bytes("")
@@ -351,7 +351,7 @@ contract TestPay_Local is JBMultiTerminalSetup {
             amount: tokenAmount,
             forwardedAmount: tokenAmount,
             weight: returnedRuleset.weight,
-            projectTokenCount: _mintAmount,
+            newlyIssuedTokenCount: _mintAmount,
             beneficiary: _bene,
             hookMetadata: bytes(""),
             payerMetadata: bytes("")


### PR DESCRIPTION
# Description

beneficiaryTokenCount takes BBH into account. 
multi terminal size is too big now, needs love.

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: