### PR TITLE
ruleset weight special case of 1

### DIFF
--- a/src/JBRulesets.sol
+++ b/src/JBRulesets.sol
@@ -1025,12 +1025,10 @@ contract JBRulesets is JBControlled, IJBRulesets {
                 mustStartAtOrAfter: mustStartAtOrAfter
             });
 
-            // A weight of 1 is treated as a weight of 0.
-            // This is to allow a weight of 0 (default) to represent inheriting the cut weight of the previous
+            // A weight of 1 is a special case that represents inheriting the cut weight of the previous
             // ruleset.
-            weight = weight > 0
-                ? (weight == 1 ? 0 : weight)
-                : deriveWeightFrom({
+            weight = weight == 1
+                ? deriveWeightFrom({
                     projectId: projectId,
                     baseRulesetStart: baseRuleset.start,
                     baseRulesetDuration: baseRuleset.duration,
@@ -1038,7 +1036,7 @@ contract JBRulesets is JBControlled, IJBRulesets {
                     baseRulesetWeightCutPercent: baseRuleset.weightCutPercent,
                     baseRulesetCacheId: baseRuleset.id,
                     start: start
-                });
+                }) : weight;
 
             // Derive the correct ruleset cycle number.
             uint256 rulesetCycleNumber = deriveCycleNumberFrom({


### PR DESCRIPTION
# Description

ruleset.weight == 1 means inherit from previous weight. all other values are interpreted normally.

this makes it clearer to configure a ruleset with no issuance (common case)... just set weight to 0.

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: